### PR TITLE
Fixes #249, adds dependencies for PyPI packaging and updates CI tests

### DIFF
--- a/.github/actions/conda-setup/action.yml
+++ b/.github/actions/conda-setup/action.yml
@@ -52,12 +52,9 @@ runs:
         else
           echo "No conda environment file found; skipping. Path: ${{ inputs.filename }}"
           mamba install -n ${{ inputs.env_name }} python=${{ inputs.python-version }}
+          sudo apt-get install libopenmpi-dev
         fi
       if: steps.cache.outputs.cache-hit != 'true'
-    - name: Install required binaries for MPI
-      shell: bash -l {0}
-      run: |
-        sudo apt-get install libopenmpi-dev
     - name: Setup the  environment
       shell: bash -l {0}
       run: |

--- a/.github/actions/conda-setup/action.yml
+++ b/.github/actions/conda-setup/action.yml
@@ -27,6 +27,7 @@ runs:
         miniforge-version: latest
         use-mamba: true
         channels: conda-forge
+        python-version: ${{ inputs.python-version }}
     - name: Update Python version in environment.yml
       shell: bash -l {0}
       run: |
@@ -47,13 +48,18 @@ runs:
     - name: Update environment
       shell: bash -l {0}
       run: |
-        if  grep -q ${{ inputs.filename }}; then
+        if grep -q ${{ inputs.filename }}; then
           mamba env update -n ${{ inputs.env_name }} -f ${{ inputs.filename }}
         else
           echo "No conda environment file found; skipping. Path: ${{ inputs.filename }}"
           mamba install -n ${{ inputs.env_name }} python=${{ inputs.python-version }}
         fi
       if: steps.cache.outputs.cache-hit != 'true'
+    - name: Dump Python version
+      shell: bash -l {0}
+      PYTHON_VERSION: ${{ inputs.python-version }}
+      run: |
+        echo "$PYTHON_VERSION"
     - name: Test environment conda package list
       shell: bash -l {0}
       run: |

--- a/.github/actions/conda-setup/action.yml
+++ b/.github/actions/conda-setup/action.yml
@@ -52,9 +52,12 @@ runs:
         else
           echo "No conda environment file found; skipping. Path: ${{ inputs.filename }}"
           mamba install -n ${{ inputs.env_name }} python=${{ inputs.python-version }}
-          conda list
         fi
       if: steps.cache.outputs.cache-hit != 'true'
+    - name: Test environment conda package list
+      shell: bash -l {0}
+      run: |
+        conda list
     - name: Install required binaries for MPI
       shell: bash -l {0}
       run: |

--- a/.github/actions/conda-setup/action.yml
+++ b/.github/actions/conda-setup/action.yml
@@ -57,7 +57,7 @@ runs:
           echo "No conda environment file found; skipping. Path: ${{ inputs.filename }}"
           mamba install -n ${{ inputs.env_name }} python=${{ inputs.python-version }}
         fi
-      #if: steps.cache.outputs.cache-hit != 'true'
+      if: steps.cache.outputs.cache-hit != 'true'
     - name: Test environment conda package list
       shell: bash -l {0}
       run: |

--- a/.github/actions/conda-setup/action.yml
+++ b/.github/actions/conda-setup/action.yml
@@ -39,11 +39,11 @@ runs:
       shell: bash -l {0}
       run: |
         echo "DATE=$(date +'%Y%m%d')" >> $GITHUB_ENV
-    - uses: actions/cache@v4
-      with:
-        path: ${{ env.CONDA }}/envs
-        key: conda-${{ hashFiles(inputs.filename) }}-${{ env.DATE }}
-      id: cache
+#    - uses: actions/cache@v4
+#      with:
+#        path: ${{ env.CONDA }}/envs
+#        key: conda-${{ hashFiles(inputs.filename) }}-${{ env.DATE }}
+#      id: cache
     - name: Update environment
       shell: bash -l {0}
       run: |

--- a/.github/actions/conda-setup/action.yml
+++ b/.github/actions/conda-setup/action.yml
@@ -19,6 +19,9 @@ inputs:
     default: "dev"
 runs:
   using: "composite"
+  defaults:
+    run:
+      shell: bash -el {0}
   steps:
     - name: Setup Miniforge
       uses: conda-incubator/setup-miniconda@v3
@@ -29,7 +32,7 @@ runs:
         channels: conda-forge
         python-version: ${{ inputs.python-version }}
     - name: Update Python version in environment.yml
-      shell: bash -l {0}
+      #shell: bash -l {0}
       run: |
         if [ -f "${{ inputs.filename }}" ]; then
           sed -i -e "s/- python>=.*/- python=${{ inputs.python-version }}/" ${{ inputs.filename }}
@@ -37,7 +40,7 @@ runs:
           grep "python=" ${{ inputs.filename }}
         fi
     - name: Set cache date
-      shell: bash -l {0}
+      #shell: bash -l {0}
       run: |
         echo "DATE=$(date +'%Y%m%d')" >> $GITHUB_ENV
     - uses: actions/cache@v4
@@ -46,34 +49,34 @@ runs:
         key: conda-${{ hashFiles(inputs.filename) }}-${{ env.DATE }}
       id: cache
     - name: Test environment conda package list
-      shell: bash -l {0}
+      #shell: bash -l {0}
       run: |
         conda list
     - name: Update environment
-      shell: bash -l {0}
+      #shell: bash -l {0}
       run: |
-        if grep -q ${{ inputs.filename }}; then
-          mamba env update -n ${{ inputs.env_name }} -f ${{ inputs.filename }}
-        else
+        if ! grep -q ${{ inputs.filename }} ; then
           echo "No conda environment file found; skipping. Path: ${{ inputs.filename }}"
-          conda install -n ${{ inputs.env_name }} python=${{ inputs.python-version }}
+          mamba install -n ${{ inputs.env_name }} python=${{ inputs.python-version }}
+        else
+          mamba env update -n ${{ inputs.env_name }} -f ${{ inputs.filename }}
         fi
       if: steps.cache.outputs.cache-hit != 'true'
     - name: Dump Python version
-      shell: bash -l {0}
+      #shell: bash -l {0}
       run: |
         echo "Python version ${{ inputs.python-version }}"
     - name: Test environment conda package list
-      shell: bash -l {0}
+      #shell: bash -l {0}
       run: |
         conda list
     - name: Install required binaries for MPI
-      shell: bash -l {0}
+      #shell: bash -l {0}
       run: |
         if ! grep -q ${{ inputs.filename }} ; then
           sudo apt install libopenmpi-dev
         fi
     - name: Setup the  environment
-      shell: bash -l {0}
+      #shell: bash -l {0}
       run: |
         python -m pip install .[${{ inputs.extras }}]

--- a/.github/actions/conda-setup/action.yml
+++ b/.github/actions/conda-setup/action.yml
@@ -57,9 +57,8 @@ runs:
       if: steps.cache.outputs.cache-hit != 'true'
     - name: Dump Python version
       shell: bash -l {0}
-      PYTHON_VERSION: ${{ inputs.python-version }}
       run: |
-        echo "$PYTHON_VERSION"
+        echo "Python version ${{ inputs.python-version }}"
     - name: Test environment conda package list
       shell: bash -l {0}
       run: |

--- a/.github/actions/conda-setup/action.yml
+++ b/.github/actions/conda-setup/action.yml
@@ -39,11 +39,11 @@ runs:
       shell: bash -l {0}
       run: |
         echo "DATE=$(date +'%Y%m%d')" >> $GITHUB_ENV
-#    - uses: actions/cache@v4
-#      with:
-#        path: ${{ env.CONDA }}/envs
-#        key: conda-${{ hashFiles(inputs.filename) }}-${{ env.DATE }}
-#      id: cache
+    - uses: actions/cache@v4
+      with:
+        path: ${{ env.CONDA }}/envs
+        key: conda-${{ hashFiles(inputs.filename) }}-${{ env.DATE }}
+      id: cache
     - name: Update environment
       shell: bash -l {0}
       run: |

--- a/.github/actions/conda-setup/action.yml
+++ b/.github/actions/conda-setup/action.yml
@@ -52,10 +52,10 @@ runs:
         else
           echo "No conda environment file found; skipping. Path: ${{ inputs.filename }}"
           mamba install -n ${{ inputs.env_name }} python=${{ inputs.python-version }}
-          sudo apt-get install libopenmpi-dev
         fi
       if: steps.cache.outputs.cache-hit != 'true'
     - name: Setup the  environment
       shell: bash -l {0}
       run: |
+        sudo apt install libopenmpi-dev
         python -m pip install .[${{ inputs.extras }}]

--- a/.github/actions/conda-setup/action.yml
+++ b/.github/actions/conda-setup/action.yml
@@ -47,7 +47,7 @@ runs:
     - name: Update environment
       shell: bash -l {0}
       run: |
-        if [ -f "${{ inputs.filename }}" ]; then
+        if  grep -q ${{ inputs.filename }}; then
           mamba env update -n ${{ inputs.env_name }} -f ${{ inputs.filename }}
         else
           echo "No conda environment file found; skipping. Path: ${{ inputs.filename }}"

--- a/.github/actions/conda-setup/action.yml
+++ b/.github/actions/conda-setup/action.yml
@@ -27,7 +27,6 @@ runs:
         miniforge-version: latest
         use-mamba: true
         channels: conda-forge
-        python-version: 3.9
     - name: Update Python version in environment.yml
       shell: bash -l {0}
       run: |
@@ -52,7 +51,7 @@ runs:
     - name: Update environment
       shell: bash -l {0}
       run: |
-        if [ -f "${{ inputs.filename }}" ] && steps.cache.outputs.cache-hit != 'true' ; then
+        if [ -f "${{ inputs.filename }}" ] && ! [ "${{ steps.cache.outputs.cache-hit }}" ] ; then
           mamba env update -n ${{ inputs.env_name }} -f ${{ inputs.filename }}
         else
           echo "No conda environment file found; skipping. Path: ${{ inputs.filename }}"

--- a/.github/actions/conda-setup/action.yml
+++ b/.github/actions/conda-setup/action.yml
@@ -52,6 +52,7 @@ runs:
         else
           echo "No conda environment file found; skipping. Path: ${{ inputs.filename }}"
           mamba install -n ${{ inputs.env_name }} python=${{ inputs.python-version }}
+          conda list
         fi
       if: steps.cache.outputs.cache-hit != 'true'
     - name: Install required binaries for MPI

--- a/.github/actions/conda-setup/action.yml
+++ b/.github/actions/conda-setup/action.yml
@@ -52,13 +52,13 @@ runs:
     - name: Update environment
       shell: bash -l {0}
       run: |
-        if [ -f "${{ inputs.filename }}" ]; then
+        if [ -f "${{ inputs.filename }}" ] && steps.cache.outputs.cache-hit != 'true' ; then
           mamba env update -n ${{ inputs.env_name }} -f ${{ inputs.filename }}
         else
           echo "No conda environment file found; skipping. Path: ${{ inputs.filename }}"
           mamba install -n ${{ inputs.env_name }} python=${{ inputs.python-version }}
         fi
-      if: steps.cache.outputs.cache-hit != 'true'
+      #if: steps.cache.outputs.cache-hit != 'true'
     - name: Test environment conda package list
       shell: bash -l {0}
       run: |

--- a/.github/actions/conda-setup/action.yml
+++ b/.github/actions/conda-setup/action.yml
@@ -54,6 +54,9 @@ runs:
           mamba install -n ${{ inputs.env_name }} python=${{ inputs.python-version }}
         fi
       if: steps.cache.outputs.cache-hit != 'true'
+    - name: Install required binaries for MPI
+      run: |
+        sudo apt-get install libopenmpi-dev
     - name: Setup the  environment
       shell: bash -l {0}
       run: |

--- a/.github/actions/conda-setup/action.yml
+++ b/.github/actions/conda-setup/action.yml
@@ -27,6 +27,7 @@ runs:
         miniforge-version: latest
         use-mamba: true
         channels: conda-forge
+        python-version: 3.9
     - name: Update Python version in environment.yml
       shell: bash -l {0}
       run: |

--- a/.github/actions/conda-setup/action.yml
+++ b/.github/actions/conda-setup/action.yml
@@ -54,8 +54,13 @@ runs:
           mamba install -n ${{ inputs.env_name }} python=${{ inputs.python-version }}
         fi
       if: steps.cache.outputs.cache-hit != 'true'
+    - name: Install required binaries for MPI
+      shell: bash -l {0}
+      run: |
+        if ![ -f "${{ inputs.filename }}" ]; then
+          sudo apt install libopenmpi-dev
+        fi
     - name: Setup the  environment
       shell: bash -l {0}
       run: |
-        sudo apt install libopenmpi-dev
         python -m pip install .[${{ inputs.extras }}]

--- a/.github/actions/conda-setup/action.yml
+++ b/.github/actions/conda-setup/action.yml
@@ -40,11 +40,11 @@ runs:
       shell: bash -l {0}
       run: |
         echo "DATE=$(date +'%Y%m%d')" >> $GITHUB_ENV
-    - uses: actions/cache@v4
-      with:
-        path: ${{ env.CONDA }}/envs
-        key: conda-${{ hashFiles(inputs.filename) }}-${{ env.DATE }}
-      id: cache
+#    - uses: actions/cache@v4
+#      with:
+#        path: ${{ env.CONDA }}/envs
+#        key: conda-${{ hashFiles(inputs.filename) }}-${{ env.DATE }}
+#      id: cache
     - name: Test environment conda package list
       shell: bash -l {0}
       run: |
@@ -59,10 +59,6 @@ runs:
           mamba install -n ${{ inputs.env_name }} -y python=${{ inputs.python-version }}
         fi
       #if: steps.cache.outputs.cache-hit != 'true'
-    - name: Dump Python version
-      shell: bash -l {0}
-      run: |
-        echo "Python version ${{ inputs.python-version }}"
     - name: Test environment conda package list
       shell: bash -l {0}
       run: |

--- a/.github/actions/conda-setup/action.yml
+++ b/.github/actions/conda-setup/action.yml
@@ -45,6 +45,10 @@ runs:
         path: ${{ env.CONDA }}/envs
         key: conda-${{ hashFiles(inputs.filename) }}-${{ env.DATE }}
       id: cache
+    - name: Test environment conda package list
+      shell: bash -l {0}
+      run: |
+        conda list
     - name: Update environment
       shell: bash -l {0}
       run: |
@@ -52,7 +56,7 @@ runs:
           mamba env update -n ${{ inputs.env_name }} -f ${{ inputs.filename }}
         else
           echo "No conda environment file found; skipping. Path: ${{ inputs.filename }}"
-          mamba install -n ${{ inputs.env_name }} python=${{ inputs.python-version }}
+          conda install -n ${{ inputs.env_name }} python=${{ inputs.python-version }}
         fi
       if: steps.cache.outputs.cache-hit != 'true'
     - name: Dump Python version

--- a/.github/actions/conda-setup/action.yml
+++ b/.github/actions/conda-setup/action.yml
@@ -27,7 +27,7 @@ runs:
         miniforge-version: latest
         use-mamba: true
         channels: conda-forge
-        python-version: ${{ inputs.python-version }}
+        #python-version: ${{ inputs.python-version }}
     - name: Update Python version in environment.yml
       shell: bash -l {0}
       run: |

--- a/.github/actions/conda-setup/action.yml
+++ b/.github/actions/conda-setup/action.yml
@@ -56,7 +56,7 @@ runs:
           mamba env update -n ${{ inputs.env_name }} -f ${{ inputs.filename }}
         else
           echo "No conda environment file found; skipping. Path: ${{ inputs.filename }}"
-          mamba install -n ${{ inputs.env_name }} python=${{ inputs.python-version }}
+          mamba install -n ${{ inputs.env_name }} -y python=${{ inputs.python-version }}
         fi
       #if: steps.cache.outputs.cache-hit != 'true'
     - name: Dump Python version

--- a/.github/actions/conda-setup/action.yml
+++ b/.github/actions/conda-setup/action.yml
@@ -55,6 +55,7 @@ runs:
         fi
       if: steps.cache.outputs.cache-hit != 'true'
     - name: Install required binaries for MPI
+      shell: bash -l {0}
       run: |
         sudo apt-get install libopenmpi-dev
     - name: Setup the  environment

--- a/.github/actions/conda-setup/action.yml
+++ b/.github/actions/conda-setup/action.yml
@@ -57,7 +57,7 @@ runs:
     - name: Install required binaries for MPI
       shell: bash -l {0}
       run: |
-        if ![ -f "${{ inputs.filename }}" ]; then
+        if ! grep -q ${{ inputs.filename }} ; then
           sudo apt install libopenmpi-dev
         fi
     - name: Setup the  environment

--- a/.github/actions/conda-setup/action.yml
+++ b/.github/actions/conda-setup/action.yml
@@ -52,11 +52,11 @@ runs:
     - name: Update environment
       shell: bash -l {0}
       run: |
-        if grep -q ${{ inputs.filename }}; then
+        if [ -f "${{ inputs.filename }}" ]; then
           mamba env update -n ${{ inputs.env_name }} -f ${{ inputs.filename }}
         else
           echo "No conda environment file found; skipping. Path: ${{ inputs.filename }}"
-          mamba install -n ${{ inputs.env_name }} -y python=${{ inputs.python-version }}
+          mamba install -n ${{ inputs.env_name }} python=${{ inputs.python-version }}
         fi
       #if: steps.cache.outputs.cache-hit != 'true'
     - name: Test environment conda package list

--- a/.github/actions/conda-setup/action.yml
+++ b/.github/actions/conda-setup/action.yml
@@ -27,7 +27,6 @@ runs:
         miniforge-version: latest
         use-mamba: true
         channels: conda-forge
-        #python-version: ${{ inputs.python-version }}
     - name: Update Python version in environment.yml
       shell: bash -l {0}
       run: |
@@ -40,11 +39,11 @@ runs:
       shell: bash -l {0}
       run: |
         echo "DATE=$(date +'%Y%m%d')" >> $GITHUB_ENV
-#    - uses: actions/cache@v4
-#      with:
-#        path: ${{ env.CONDA }}/envs
-#        key: conda-${{ hashFiles(inputs.filename) }}-${{ env.DATE }}
-#      id: cache
+    - uses: actions/cache@v4
+      with:
+        path: ${{ env.CONDA }}/envs
+        key: conda-${{ hashFiles(inputs.filename) }}-${{ env.DATE }}
+      id: cache
     - name: Test environment conda package list
       shell: bash -l {0}
       run: |

--- a/.github/actions/conda-setup/action.yml
+++ b/.github/actions/conda-setup/action.yml
@@ -44,10 +44,6 @@ runs:
         path: ${{ env.CONDA }}/envs
         key: conda-${{ hashFiles(inputs.filename) }}-${{ env.DATE }}
       id: cache
-    - name: Test environment conda package list
-      shell: bash -l {0}
-      run: |
-        conda list
     - name: Update environment
       shell: bash -l {0}
       run: |
@@ -57,11 +53,6 @@ runs:
           echo "No conda environment file found; skipping. Path: ${{ inputs.filename }}"
           mamba install -n ${{ inputs.env_name }} python=${{ inputs.python-version }}
         fi
-      #if: steps.cache.outputs.cache-hit != 'true'
-    - name: Test environment conda package list
-      shell: bash -l {0}
-      run: |
-        conda list
     - name: Install required binaries for MPI
       shell: bash -l {0}
       run: |

--- a/.github/actions/conda-setup/action.yml
+++ b/.github/actions/conda-setup/action.yml
@@ -19,9 +19,6 @@ inputs:
     default: "dev"
 runs:
   using: "composite"
-  defaults:
-    run:
-      shell: bash -el {0}
   steps:
     - name: Setup Miniforge
       uses: conda-incubator/setup-miniconda@v3
@@ -32,7 +29,7 @@ runs:
         channels: conda-forge
         python-version: ${{ inputs.python-version }}
     - name: Update Python version in environment.yml
-      #shell: bash -l {0}
+      shell: bash -l {0}
       run: |
         if [ -f "${{ inputs.filename }}" ]; then
           sed -i -e "s/- python>=.*/- python=${{ inputs.python-version }}/" ${{ inputs.filename }}
@@ -40,7 +37,7 @@ runs:
           grep "python=" ${{ inputs.filename }}
         fi
     - name: Set cache date
-      #shell: bash -l {0}
+      shell: bash -l {0}
       run: |
         echo "DATE=$(date +'%Y%m%d')" >> $GITHUB_ENV
     - uses: actions/cache@v4
@@ -49,34 +46,34 @@ runs:
         key: conda-${{ hashFiles(inputs.filename) }}-${{ env.DATE }}
       id: cache
     - name: Test environment conda package list
-      #shell: bash -l {0}
+      shell: bash -l {0}
       run: |
         conda list
     - name: Update environment
-      #shell: bash -l {0}
+      shell: bash -l {0}
       run: |
-        if ! grep -q ${{ inputs.filename }} ; then
+        if grep -q ${{ inputs.filename }}; then
+          mamba env update -n ${{ inputs.env_name }} -f ${{ inputs.filename }}
+        else
           echo "No conda environment file found; skipping. Path: ${{ inputs.filename }}"
           mamba install -n ${{ inputs.env_name }} python=${{ inputs.python-version }}
-        else
-          mamba env update -n ${{ inputs.env_name }} -f ${{ inputs.filename }}
         fi
-      if: steps.cache.outputs.cache-hit != 'true'
+      #if: steps.cache.outputs.cache-hit != 'true'
     - name: Dump Python version
-      #shell: bash -l {0}
+      shell: bash -l {0}
       run: |
         echo "Python version ${{ inputs.python-version }}"
     - name: Test environment conda package list
-      #shell: bash -l {0}
+      shell: bash -l {0}
       run: |
         conda list
     - name: Install required binaries for MPI
-      #shell: bash -l {0}
+      shell: bash -l {0}
       run: |
         if ! grep -q ${{ inputs.filename }} ; then
           sudo apt install libopenmpi-dev
         fi
     - name: Setup the  environment
-      #shell: bash -l {0}
+      shell: bash -l {0}
       run: |
         python -m pip install .[${{ inputs.extras }}]

--- a/environment.yml
+++ b/environment.yml
@@ -25,16 +25,11 @@ dependencies:
   - jupyterlab>=3
   - jupyterlab-lsp
   - python-lsp-server
-  - matplotlib
   - pygments
   - mkdocs
   - mkdocstrings
   - mkdocs-material
-  # NOTE: we are installing mkdocs-jupyter with pip for now
-  # due to the following: https://github.com/conda-forge/mkdocs-jupyter-feedstock/issues/31
-  # - mkdocs-jupyter
+  - mkdocs-jupyter
   - mkdocstrings-python
   - ruff
   - typing-extensions
-  - pip:
-      - mkdocs-jupyter>=0.24.7

--- a/environment.yml
+++ b/environment.yml
@@ -14,6 +14,7 @@ dependencies:
   - ipywidgets
   - tqdm
   - orjson
+  - matplotlib
 # parallel
   - mpi4py
   - dask

--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,7 @@ channels:
 dependencies:
   - python>=3.9
   - deap
-  - numpy
+  - numpy>=2.1.0
   - pydantic>=2.3
   - pyyaml
   - botorch>=0.9.2,<=0.10.0

--- a/environment_.yml
+++ b/environment_.yml
@@ -5,7 +5,7 @@ channels:
 dependencies:
   - python>=3.9
   - deap
-  - numpy>=2.1.0
+  - numpy
   - pydantic>=2.3
   - pyyaml
   - botorch>=0.9.2,<=0.10.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,8 +17,17 @@ classifiers = [
   "Topic :: Scientific/Engineering",
 ]
 dependencies = [
-  # All core dependencies must be sourced from conda (conda-forge).
-  # See ``environment.yml`` for further information.
+  "deap",
+  "numpy",
+  "pydantic>=2.3",
+  "pyyaml",
+  "botorch>=0.9.2,<=0.10.0",
+  "scipy>=1.10.1",
+  "pandas",
+  "ipywidgets",
+  "tqdm",
+  "orjson",
+  "matplotlib"
 ]
 description = "Flexible optimization of arbitrary problems in Python."
 dynamic = [ "version" ]
@@ -31,6 +40,15 @@ requires-python = ">=3.9"
 dev = [
   "pytest",
   "pytest-cov",
+  "ffmpeg",
+  "pytest",
+  "pytest-cov",
+  "jupyterlab>=3",
+  "jupyterlab-lsp",
+  "python-lsp-server",
+  "pygments",
+  "dask",
+  "mpi4py"
 ]
 doc = [
   "mkdocs",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,8 +48,7 @@ dev = [
   "python-lsp-server",
   "pygments",
   "dask",
-  "mpi4py",
-  "libopenmpi-dev"
+  "mpi4py"
 ]
 doc = [
   "mkdocs",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,8 @@ dev = [
   "python-lsp-server",
   "pygments",
   "dask",
-  "mpi4py"
+  "mpi4py",
+  "libopenmpi-dev"
 ]
 doc = [
   "mkdocs",


### PR DESCRIPTION
- updated pyproject.toml
    - added deps based on environment.yml
    -  `dask` and `mpi4py` added to dev deps based on conda-forge recipe
- updated environment.yml
    - matplotlib moved from deps to "regular" deps based on feedback from Ryan
    - adjusted `mkdocs-jupyter` install since [#31](https://github.com/conda-forge/mkdocs-jupyter-feedstock/issues/31) is resolved
- updated conda-setup/action.yml to support pip install if/when environment.yml is not available
    - when environment.yml is not available, the conda runner will install python=3.12 by default, checking for this regardless of the cache existing avoids errors wrt the python version
    - added binaries needed for MPI when a pip install is done