### PR TITLE
CNSGA Output Filenames

### DIFF
--- a/xopt/generators/ga/cnsga.py
+++ b/xopt/generators/ga/cnsga.py
@@ -123,7 +123,8 @@ class CNSGAGenerator(Generator):
             return
 
         if filename is None:
-            filename = f"{self.name}_offspring_{xopt.utils.isotime(include_microseconds=True)}.csv"
+            timestamp = xopt.utils.isotime(include_microseconds=True).replace(":", "_")
+            filename = f"{self.name}_offspring_{timestamp}.csv"
             filename = os.path.join(self.output_path, filename)
 
         self._offspring.to_csv(filename, index_label="xopt_index")
@@ -139,9 +140,9 @@ class CNSGAGenerator(Generator):
             return
 
         if filename is None:
-            filename = f"{self.name}_population_{xopt.utils.isotime(include_microseconds=True)}.csv"
+            timestamp = xopt.utils.isotime(include_microseconds=True).replace(":", "_")
+            filename = f"{self.name}_population_{timestamp}.csv"
             filename = os.path.join(self.output_path, filename)
-            filename = filename.replace(":", "_")
 
         self.population.to_csv(filename, index_label="xopt_index")
 


### PR DESCRIPTION
This PR includes the following two changes proposed to allow users on Windows to run the CNSGA generator with file output.
- `CNSGAGenerator.write_offspring` has been updated to avoid the colon character in filenames similarly to `write_population` in #251
- The string replacement for colon characters in filenames has been moved to only apply to the timestamp. This avoids causing problems when `self.output_path` looks like "C:\Users\yourname\project\dir"