### PR TITLE
Update lint.yml to mamba install

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,7 +19,7 @@ jobs:
 
       - name: Install pre-commit
         shell: bash -l {0}
-        run: conda install pre-commit nbconvert
+        run: mamba install pre-commit nbconvert
 
       - name: List Python package versions
         shell: bash -l {0}


### PR DESCRIPTION
Not sure why this happened (maybe some upstream updates w/ mamba or the problem packages) but this seems to fix it, and it's consistent with how we're installing packages in the env in the conda action.