### PR TITLE
Update gh-pages.yml deploy version

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -61,4 +61,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v3
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
To deploy site uploaded with actions/upload-pages-artifact@v3, we need actions/deploy-pages@v4 or newer.