### PR TITLE
Pin mamba and botorch

### DIFF
--- a/.github/actions/conda-setup/action.yml
+++ b/.github/actions/conda-setup/action.yml
@@ -25,7 +25,6 @@ runs:
       with:
         activate-environment: ${{ inputs.env_name }}
         miniforge-version: latest
-        use-mamba: true
         mamba-version: "2.0.5"
         channels: conda-forge
     - name: Update Python version in environment.yml

--- a/.github/actions/conda-setup/action.yml
+++ b/.github/actions/conda-setup/action.yml
@@ -26,6 +26,7 @@ runs:
         activate-environment: ${{ inputs.env_name }}
         miniforge-version: latest
         use-mamba: true
+        mamba-version: "2.0.5"
         channels: conda-forge
     - name: Update Python version in environment.yml
       shell: bash -l {0}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
   "numpy",
   "pydantic>=2.3",
   "pyyaml",
-  "botorch>=0.12.0",
+  "botorch==0.12.0",
   "scipy>=1.10.1",
   "pandas",
   "ipywidgets",


### PR DESCRIPTION
I pinned the mamba version until `setup-miniconda` merges in the conda/mamba fix. I also pinned the botorch version until we adjust our tests to v0.13.0 (errors observed on Badger CI/CD).