### PR TITLE
Turbo maximization sign fix

### DIFF
--- a/xopt/generators/bayesian/turbo.py
+++ b/xopt/generators/bayesian/turbo.py
@@ -344,6 +344,7 @@ class OptimizeTurboController(TurboController):
         recent_data = data.iloc[-previous_batch_size:]
         f_data = self.vocs.feasibility_data(recent_data)
         recent_f_data = recent_data[f_data["feasible"]]
+        recent_f_data_minform = self.vocs.objective_data(recent_f_data, "")
 
         # if none of the candidates are valid count this as a failure
         if len(recent_f_data) == 0:
@@ -354,9 +355,10 @@ class OptimizeTurboController(TurboController):
             # if we had previous feasible points we need to compare with previous
             # best values, NOTE: this is the opposite of botorch which assumes
             # maximization, xopt assumes minimization
-            Y_last = recent_f_data[self.vocs.objective_names[0]].min()
+            Y_last = recent_f_data_minform[self.vocs.objective_names[0]].min()
+            best_value = self.best_value if self.minimize else -self.best_value
 
-            if Y_last < self.best_value + 1e-3 * math.fabs(self.best_value):
+            if Y_last < best_value + 1e-3 * math.fabs(best_value):
                 self.success_counter += 1
                 self.failure_counter = 0
             else:

--- a/xopt/tests/generators/bayesian/test_turbo.py
+++ b/xopt/tests/generators/bayesian/test_turbo.py
@@ -115,6 +115,89 @@ class TestTurbo(TestCase):
         assert np.all(tr[1].numpy() <= test_vocs.bounds[1])
 
     @patch.multiple(BayesianGenerator, __abstractmethods__=set())
+    def test_sign_conventions(self):
+        # 2D minimization
+        test_vocs = deepcopy(TEST_VOCS_BASE)
+        gen = BayesianGenerator(vocs=test_vocs)
+        # ensure first update will be a failure
+        data = TEST_VOCS_DATA.copy()
+        data.loc[:, "y1"].iloc[-1] = data['y1'].max()
+        gen.add_data(data)
+        gen.train_model()
+
+        turbo_state = OptimizeTurboController(gen.vocs)
+        turbo_state.update_state(gen)
+        assert turbo_state.success_counter == 0
+        assert turbo_state.failure_counter == 1
+
+        # make next step to better (lower) value
+        test_data = {
+            "x1": [0.1234],
+            "x2": [0.1234],
+            "c1": [1.0],
+            "y1": [TEST_VOCS_DATA['y1'].min() - 1.0]
+        }
+        gen.add_data(pd.DataFrame(test_data))
+        gen.train_model()
+        turbo_state.update_state(gen)
+        assert turbo_state.success_counter == 1
+        assert turbo_state.failure_counter == 0
+
+        # make next step to worse (higher) value
+        test_data = {
+            "x1": [0.2345],
+            "x2": [0.2345],
+            "c1": [1.0],
+            "y1": [TEST_VOCS_DATA['y1'].max() + 1.0]
+        }
+        gen.add_data(pd.DataFrame(test_data))
+        gen.train_model()
+        turbo_state.update_state(gen)
+        assert turbo_state.success_counter == 0
+        assert turbo_state.failure_counter == 1
+
+        # 2D maximization
+        test_vocs = deepcopy(TEST_VOCS_BASE)
+        test_vocs.objectives["y1"] = "MAXIMIZE"
+        gen = BayesianGenerator(vocs=test_vocs)
+        # ensure first update will be a failure
+        data = TEST_VOCS_DATA.copy()
+        data.loc[:, "y1"].iloc[-1] = data['y1'].min()
+        gen.add_data(data)
+        gen.train_model()
+
+        turbo_state = OptimizeTurboController(gen.vocs)
+        turbo_state.update_state(gen)
+        assert turbo_state.success_counter == 0
+        assert turbo_state.failure_counter == 1
+
+        # make next step to better (higher) value
+        test_data = {
+            "x1": [0.1234],
+            "x2": [0.1234],
+            "c1": [1.0],
+            "y1": [TEST_VOCS_DATA['y1'].max() + 1.0]
+        }
+        gen.add_data(pd.DataFrame(test_data))
+        gen.train_model()
+        turbo_state.update_state(gen)
+        assert turbo_state.success_counter == 1
+        assert turbo_state.failure_counter == 0
+
+        # make next step to worse (lower) value
+        test_data = {
+            "x1": [0.2345],
+            "x2": [0.2345],
+            "c1": [1.0],
+            "y1": [TEST_VOCS_DATA['y1'].min() - 1.0]
+        }
+        gen.add_data(pd.DataFrame(test_data))
+        gen.train_model()
+        turbo_state.update_state(gen)
+        assert turbo_state.success_counter == 0
+        assert turbo_state.failure_counter == 1
+
+    @patch.multiple(BayesianGenerator, __abstractmethods__=set())
     def test_restrict_data(self):
         # test in 1D
         test_vocs = deepcopy(TEST_VOCS_BASE)

--- a/xopt/tests/generators/bayesian/test_turbo.py
+++ b/xopt/tests/generators/bayesian/test_turbo.py
@@ -121,7 +121,7 @@ class TestTurbo(TestCase):
         gen = BayesianGenerator(vocs=test_vocs)
         # ensure first update will be a failure
         data = TEST_VOCS_DATA.copy()
-        data.loc[:, "y1"].iloc[-1] = data['y1'].max()
+        data.loc[:, "y1"].iloc[-1] = data["y1"].max()
         gen.add_data(data)
         gen.train_model()
 
@@ -135,7 +135,7 @@ class TestTurbo(TestCase):
             "x1": [0.1234],
             "x2": [0.1234],
             "c1": [1.0],
-            "y1": [TEST_VOCS_DATA['y1'].min() - 1.0]
+            "y1": [TEST_VOCS_DATA["y1"].min() - 1.0],
         }
         gen.add_data(pd.DataFrame(test_data))
         gen.train_model()
@@ -148,7 +148,7 @@ class TestTurbo(TestCase):
             "x1": [0.2345],
             "x2": [0.2345],
             "c1": [1.0],
-            "y1": [TEST_VOCS_DATA['y1'].max() + 1.0]
+            "y1": [TEST_VOCS_DATA["y1"].max() + 1.0],
         }
         gen.add_data(pd.DataFrame(test_data))
         gen.train_model()
@@ -162,7 +162,7 @@ class TestTurbo(TestCase):
         gen = BayesianGenerator(vocs=test_vocs)
         # ensure first update will be a failure
         data = TEST_VOCS_DATA.copy()
-        data.loc[:, "y1"].iloc[-1] = data['y1'].min()
+        data.loc[:, "y1"].iloc[-1] = data["y1"].min()
         gen.add_data(data)
         gen.train_model()
 
@@ -176,7 +176,7 @@ class TestTurbo(TestCase):
             "x1": [0.1234],
             "x2": [0.1234],
             "c1": [1.0],
-            "y1": [TEST_VOCS_DATA['y1'].max() + 1.0]
+            "y1": [TEST_VOCS_DATA["y1"].max() + 1.0],
         }
         gen.add_data(pd.DataFrame(test_data))
         gen.train_model()
@@ -189,7 +189,7 @@ class TestTurbo(TestCase):
             "x1": [0.2345],
             "x2": [0.2345],
             "c1": [1.0],
-            "y1": [TEST_VOCS_DATA['y1'].min() - 1.0]
+            "y1": [TEST_VOCS_DATA["y1"].min() - 1.0],
         }
         gen.add_data(pd.DataFrame(test_data))
         gen.train_model()


### PR DESCRIPTION
Sign discrepancy between data and best value for maximization objectives causes turbo controller to make opposite actions. Didn't check other turbo classes - might be issues there too. Discovered with unit testing mirror functions (negation of eval_f and objective + comparing convergence) - need to add later.