### PR TITLE
Add BAX in the automated API documentation

### DIFF
--- a/docs/api/generators/bayesian.md
+++ b/docs/api/generators/bayesian.md
@@ -16,3 +16,4 @@
 - minimize
 ::: xopt.generators.bayesian.turbo.SafetyTurboController
 ::: xopt.generators.bayesian.turbo.EntropyTurboController
+::: xopt.generators.bayesian.bax_generator.BaxGenerator


### PR DESCRIPTION
BAX was missing from the API documentation.