### PR TITLE
NSGA2 Generator NaN Handling in `crowded_comparison_argsort` Bugfix

### DIFF
--- a/xopt/generators/ga/nsga2.py
+++ b/xopt/generators/ga/nsga2.py
@@ -72,6 +72,8 @@ def crowded_comparison_argsort(
     Sorts the objective functions by domination rank and then by crowding distance (crowded comparison operator).
     Indices to individuals are returned in order of increasing value by crowded comparison operator.
 
+    Notes: individuals containing `nan` values will be assigned the last domination rank.
+
     Parameters
     ----------
     pop_f : np.ndarray
@@ -86,10 +88,10 @@ def crowded_comparison_argsort(
     """
     # Deal with NaNs
     pop_f = np.copy(pop_f)
-    pop_f[~np.isfinite(pop_f)] = 1e300
+    pop_f[~np.isfinite(pop_f)] = np.inf
     if pop_g is not None:
         pop_g = np.copy(pop_g)
-        pop_g[~np.isfinite(pop_g)] = 1e300
+        pop_g[~np.isfinite(pop_g)] = np.inf
 
     ranks = fast_dominated_argsort(pop_f, pop_g)
     inds = []

--- a/xopt/generators/ga/nsga2.py
+++ b/xopt/generators/ga/nsga2.py
@@ -29,7 +29,7 @@ def vocs_data_to_arr(data: list | np.ndarray) -> np.ndarray:
     """Force data coming from VOCS object into 2D numpy array (or None) for compatibility with helper functions"""
     if isinstance(data, list):
         data = np.ndarray(list)
-    if len(data.shape) == 0:
+    if data.size == 0:
         return None
     if len(data.shape) == 1:
         return data[:, None]

--- a/xopt/generators/ga/nsga2.py
+++ b/xopt/generators/ga/nsga2.py
@@ -24,6 +24,7 @@ from .operators import (
 # Helper functions
 ########################################################################################################################
 
+
 def vocs_data_to_arr(data: list | np.ndarray) -> np.ndarray:
     """Force data coming from VOCS object into 2D numpy array (or None) for compatibility with helper functions"""
     if isinstance(data, list):
@@ -106,33 +107,33 @@ def crowded_comparison_argsort(
         has_nan = has_nan | np.any(~np.isfinite(pop_g), axis=1)
     nan_indices = np.where(has_nan)[0]
     finite_indices = np.where(~has_nan)[0]
-    
+
     # If all values are non-finite, return the original indices
     if len(finite_indices) == 0:
         return np.arange(pop_f.shape[0])
-    
+
     # Extract only finite values for processing
     pop_f_finite = pop_f[finite_indices, :]
-    
+
     # Handle constraints if provided
     pop_g_finite = None
     if pop_g is not None:
         pop_g_finite = pop_g[finite_indices, :]
-    
+
     # Apply domination ranking
     ranks = fast_dominated_argsort(pop_f_finite, pop_g_finite)
-    
+
     # Calculate crowding distance and sort within each rank
     sorted_finite_indices = []
     for rank in ranks:
         dist = get_crowding_distance(pop_f_finite[rank, :])
         sorted_rank = np.array(rank)[np.argsort(dist)[::-1]]
         sorted_finite_indices.extend(sorted_rank)
-    
+
     # Map back to original indices and put nans at end
     sorted_original_indices = finite_indices[sorted_finite_indices]
     final_sorted_indices = np.concatenate([sorted_original_indices, nan_indices])
-    
+
     return final_sorted_indices[::-1]
 
 

--- a/xopt/generators/ga/nsga2.py
+++ b/xopt/generators/ga/nsga2.py
@@ -86,7 +86,7 @@ def crowded_comparison_argsort(
     """
     # Deal with NaNs
     pop_f = np.copy(pop_f)
-    pop_f[~np.isfinite(pop_g)] = 1e300
+    pop_f[~np.isfinite(pop_f)] = 1e300
     if pop_g is not None:
         pop_g = np.copy(pop_g)
         pop_g[~np.isfinite(pop_g)] = 1e300

--- a/xopt/generators/ga/nsga2.py
+++ b/xopt/generators/ga/nsga2.py
@@ -24,6 +24,18 @@ from .operators import (
 # Helper functions
 ########################################################################################################################
 
+def vocs_data_to_arr(data: list | np.ndarray) -> np.ndarray:
+    """Force data coming from VOCS object into 2D numpy array (or None) for compatibility with helper functions"""
+    if isinstance(data, list):
+        data = np.ndarray(list)
+    if len(data.shape) == 0:
+        return None
+    if len(data.shape) == 1:
+        return data[:, None]
+    if len(data.shape) == 2:
+        return data
+    raise ValueError(f"Unrecognized shape from VOCS data: {data.shape}")
+
 
 def get_crowding_distance(pop_f: np.ndarray) -> np.ndarray:
     """
@@ -368,7 +380,7 @@ class NSGA2Generator(DeduplicatedGeneratorBase, StateOwner):
             candidates = []
             pop_x = self.vocs.variable_data(self.pop).to_numpy()
             pop_f = self.vocs.objective_data(self.pop).to_numpy()
-            pop_g = self.vocs.constraint_data(self.pop).to_numpy() if self.vocs.constraint_names else None
+            pop_g = vocs_data_to_arr(self.vocs.constraint_data(self.pop).to_numpy())
             fitness = get_fitness(pop_f, pop_g)
             for _ in range(n_candidates):
                 candidates.append(
@@ -440,7 +452,7 @@ class NSGA2Generator(DeduplicatedGeneratorBase, StateOwner):
             idx = cull_population(
                 self.vocs.variable_data(self.pop).to_numpy(),
                 self.vocs.objective_data(self.pop).to_numpy(),
-                self.vocs.constraint_data(self.pop).to_numpy() if self.vocs.constraint_names else None,
+                vocs_data_to_arr(self.vocs.constraint_data(self.pop).to_numpy()),
                 self.population_size,
             )
             self.pop = [self.pop[i] for i in idx]

--- a/xopt/generators/utils.py
+++ b/xopt/generators/utils.py
@@ -1,9 +1,8 @@
 # from xopt.generator import Generator
 import numpy as np
-from typing import List, Optional
 
 
-def get_domination(pop_f: np.ndarray, pop_g: Optional[np.ndarray] = None) -> np.ndarray:
+def get_domination(pop_f: np.ndarray, pop_g: np.ndarray | None = None) -> np.ndarray:
     """
     Compute domination matrix for a population based on objective values and constraints. Determines domination
     relationships between all pairs of individuals in a population.
@@ -46,7 +45,7 @@ def get_domination(pop_f: np.ndarray, pop_g: Optional[np.ndarray] = None) -> np.
     return dom
 
 
-def fast_dominated_argsort_internal(dom: np.ndarray) -> List[np.ndarray]:
+def fast_dominated_argsort_internal(dom: np.ndarray) -> list[np.ndarray]:
     """
     Used inside of `fast_dominated_argsort`. Call that function instead.
 
@@ -83,8 +82,8 @@ def fast_dominated_argsort_internal(dom: np.ndarray) -> List[np.ndarray]:
 
 
 def fast_dominated_argsort(
-    pop_f: np.ndarray, pop_g: Optional[np.ndarray] = None
-) -> List[np.ndarray]:
+    pop_f: np.ndarray, pop_g: np.ndarray | None = None
+) -> list[np.ndarray]:
     """
     Performs a dominated sort on matrix of objective function values O.  This is a numpy implementation of the algorithm
     described in [1].

--- a/xopt/tests/generators/ga/test_nsga2.py
+++ b/xopt/tests/generators/ga/test_nsga2.py
@@ -5,12 +5,14 @@ from datetime import datetime
 
 import numpy as np
 import pandas as pd
+import pytest
 
 from xopt.base import Xopt
 from xopt.evaluator import Evaluator
 from xopt.generators.ga.nsga2 import (
     NSGA2Generator,
     generate_child_binary_tournament,
+    crowded_comparison_argsort,
 )
 from xopt.generators.ga.operators import PolynomialMutation, SimulatedBinaryCrossover
 from xopt.resources.test_functions.tnk import evaluate_TNK, tnk_vocs
@@ -397,3 +399,17 @@ def test_resume_consistency(pop_size=5, n_steps=128, check_step=10):
             np.random.seed(42)
             samples = X.generator.generate(1)
             X.evaluate_data(samples)
+
+
+@pytest.mark.parametrize(
+        "pop_f, pop_g",
+        [
+            (np.random.random((128, 4)), None),
+            (np.random.random((128, 4)), np.random.random((128, 4))),
+            (np.random.random((128, 4)), np.random.random((128, 2))),
+            (np.random.random((128, 4)), np.random.random((128, 1))),
+        ]
+    )
+def test_crowded_comparison_argsort(pop_f, pop_g):
+    """Confirm no errors on running with variety of inputs"""
+    crowded_comparison_argsort(pop_f, pop_g)

--- a/xopt/tests/generators/ga/test_nsga2.py
+++ b/xopt/tests/generators/ga/test_nsga2.py
@@ -402,14 +402,79 @@ def test_resume_consistency(pop_size=5, n_steps=128, check_step=10):
 
 
 @pytest.mark.parametrize(
-        "pop_f, pop_g",
-        [
-            (np.random.random((128, 4)), None),
-            (np.random.random((128, 4)), np.random.random((128, 4))),
-            (np.random.random((128, 4)), np.random.random((128, 2))),
-            (np.random.random((128, 4)), np.random.random((128, 1))),
-        ]
-    )
-def test_crowded_comparison_argsort(pop_f, pop_g):
-    """Confirm no errors on running with variety of inputs"""
-    crowded_comparison_argsort(pop_f, pop_g)
+    "pop_f, pop_g, expected_indices_options",
+    [
+        # Two individuals in different ranks
+        (
+            np.array([[1.0, 2.0], [2.0, 3.0]]),
+            None,
+            [np.array([1, 0])]
+        ),
+        # Non-dominated, different crowding distances
+        (
+            np.array([[1.0, 3.0], [2.0, 2.0], [3.0, 1.0]]),
+            None,
+            [np.array([1, 2, 0]), np.array([1, 0, 2])]
+        ),
+        # NaN values
+        (
+            np.array([[1.0, 2.0], [np.nan, 3.0], [2.0, 1.0]]),
+            None,
+            [np.array([1, 2, 0]), np.array([1, 0, 2])]
+        ),
+        # Constrained
+        (
+            np.array([[2.0, 2.0], [1.0, 1.0]]),
+            np.array([[-1.0, -1.0], [1.0, -1.0]]),
+            [np.array([1, 0])]
+        ),
+        # Multiple individuals with same rank but potentially same crowding distances
+        (
+            np.array([[1.0, 3.0], [2.0, 2.0], [3.0, 1.0], [1.5, 2.5]]),
+            None,
+            [
+                np.array([3, 1, 2, 0]),
+                np.array([1, 3, 2, 0]),
+                np.array([3, 1, 0, 2]),
+                np.array([1, 3, 0, 2]),
+            ]
+        ),
+        # NaN values and constraints
+        (
+            np.array([[1.0, 2.0], [np.nan, 3.0], [2.0, 1.0]]),
+            np.array([[-1.0, -1.0, -1.0], [0.0, 0.0, 0.0], [1.0, 0.0, 0.0]]),
+            [np.array([1, 2, 0])]
+        ),
+        # All NaN
+        (
+            np.array([[np.nan, np.nan], [np.nan, np.nan]]),
+            None,
+            [np.array([0, 1]), np.array([1, 0])]
+        ),
+    ],
+)
+def test_crowded_comparison_argsort(pop_f, pop_g, expected_indices_options):
+    """
+    Test the crowded_comparison_argsort function with various explicit input.
+    
+    Parameters
+    ----------
+    pop_f : numpy.ndarray
+        Objective values
+    pop_g : numpy.ndarray or None
+        Constraint values
+    expected_indices_options : list of numpy.ndarray
+        List of valid expected sorted indices
+    """
+    # Call the function
+    result = crowded_comparison_argsort(pop_f, pop_g)
+    
+    # Check if the result matches any of the expected options
+    matches_any = any(np.array_equal(result, expected) for expected in expected_indices_options)
+    
+    if not matches_any:
+        message = (
+            f"Result {result} doesn't match any expected ordering.\n"
+            f"Expected one of: {expected_indices_options}"
+        )
+        assert False, message

--- a/xopt/tests/generators/ga/test_nsga2.py
+++ b/xopt/tests/generators/ga/test_nsga2.py
@@ -405,28 +405,24 @@ def test_resume_consistency(pop_size=5, n_steps=128, check_step=10):
     "pop_f, pop_g, expected_indices_options",
     [
         # Two individuals in different ranks
-        (
-            np.array([[1.0, 2.0], [2.0, 3.0]]),
-            None,
-            [np.array([1, 0])]
-        ),
+        (np.array([[1.0, 2.0], [2.0, 3.0]]), None, [np.array([1, 0])]),
         # Non-dominated, different crowding distances
         (
             np.array([[1.0, 3.0], [2.0, 2.0], [3.0, 1.0]]),
             None,
-            [np.array([1, 2, 0]), np.array([1, 0, 2])]
+            [np.array([1, 2, 0]), np.array([1, 0, 2])],
         ),
         # NaN values
         (
             np.array([[1.0, 2.0], [np.nan, 3.0], [2.0, 1.0]]),
             None,
-            [np.array([1, 2, 0]), np.array([1, 0, 2])]
+            [np.array([1, 2, 0]), np.array([1, 0, 2])],
         ),
         # Constrained
         (
             np.array([[2.0, 2.0], [1.0, 1.0]]),
             np.array([[-1.0, -1.0], [1.0, -1.0]]),
-            [np.array([1, 0])]
+            [np.array([1, 0])],
         ),
         # Multiple individuals with same rank but potentially same crowding distances
         (
@@ -437,26 +433,26 @@ def test_resume_consistency(pop_size=5, n_steps=128, check_step=10):
                 np.array([1, 3, 2, 0]),
                 np.array([3, 1, 0, 2]),
                 np.array([1, 3, 0, 2]),
-            ]
+            ],
         ),
         # NaN values and constraints
         (
             np.array([[1.0, 2.0], [np.nan, 3.0], [2.0, 1.0]]),
             np.array([[-1.0, -1.0, -1.0], [0.0, 0.0, 0.0], [1.0, 0.0, 0.0]]),
-            [np.array([1, 2, 0])]
+            [np.array([1, 2, 0])],
         ),
         # All NaN
         (
             np.array([[np.nan, np.nan], [np.nan, np.nan]]),
             None,
-            [np.array([0, 1]), np.array([1, 0])]
+            [np.array([0, 1]), np.array([1, 0])],
         ),
     ],
 )
 def test_crowded_comparison_argsort(pop_f, pop_g, expected_indices_options):
     """
     Test the crowded_comparison_argsort function with various explicit input.
-    
+
     Parameters
     ----------
     pop_f : numpy.ndarray
@@ -468,10 +464,12 @@ def test_crowded_comparison_argsort(pop_f, pop_g, expected_indices_options):
     """
     # Call the function
     result = crowded_comparison_argsort(pop_f, pop_g)
-    
+
     # Check if the result matches any of the expected options
-    matches_any = any(np.array_equal(result, expected) for expected in expected_indices_options)
-    
+    matches_any = any(
+        np.array_equal(result, expected) for expected in expected_indices_options
+    )
+
     if not matches_any:
         message = (
             f"Result {result} doesn't match any expected ordering.\n"


### PR DESCRIPTION
## Problem Description
Line 89 in `xopt/generators/ga/nsga2.py` is the following.
```python
pop_f[~np.isfinite(pop_g)] = 1e300 
```
It should have read as this.
```python
pop_f[~np.isfinite(pop_f)] = 1e300 
```
This will cause an error in the specific case that a problem has more than one constraint and the number of constraints is not equal to the number of objectives. 

## Changes in PR
This PR adds a unit test that triggers on the bug, fixes the bug, and refactors how NaNs are handled in `crowded_comparison_argsort`. A complete set of changes are the following.
 - New unit test `test_crowded_comparison_argsort` which errors out due to the previous bug. It test a set of populations and their manually calculated fitness orderings against the function. The cases include instances with more than one constraint and a different number of constraints than objects. It also includes some examples with NaNs to check that they are handled correctly.
 - While I was in there, I refactored `crowded_comparison_argsort` to better handle NaNs. Now, instead of overriting them with large values which should trigger the domination sorting code to place them last, they are removed. The safe individuals are then sorted and the ones containing NaN are added as the least fit individuals in no particular order. This handling is more explicit and doesn't rely on assumptions of how the rest of the sorting code works.
 - The old code was OK with accepting `pop_g` as an empty numpy array when there are no constraints. These functions are really designed to take either a 2D numpy array or `None` if there are no constraints. I added the new helper function `vocs_data_to_arr` which casts anything coming out of `VOCS.constraint_data(...)` into either a 2D array or `None`. This function was then used to wrap the relevant calls inside of `NSGA2Generator`.
 - The python type annotation used in nsga2 generator code was updated to be of [the more modern style](https://peps.python.org/pep-0585/).
 - Besides unit tests, I ran regression tests on the WFG and CF problems from [ParetoBench](https://github.com/electronsandstuff/ParetoBench/tree/main) and confirmed I get the same performance as the version of `NSGA2Generator` in the main branch.