### PR TITLE
Fix optimum search with fixed features

### DIFF
--- a/xopt/generators/bayesian/bayesian_generator.py
+++ b/xopt/generators/bayesian/bayesian_generator.py
@@ -573,13 +573,16 @@ class BayesianGenerator(Generator, ABC):
     def get_optimum(self):
         """select the best point(s) given by the
         model using the Posterior mean"""
-        acq = ConstrainedMCAcquisitionFunction(
-            self.model,
-            qUpperConfidenceBound(
-                model=self.model, beta=0.0, objective=self._get_objective()
-            ),
-            self._get_constraint_callables(),
+        acq = qUpperConfidenceBound(
+            model=self.model, beta=0.0, objective=self._get_objective()
         )
+        if len(self.vocs.constraints):
+            acq = ConstrainedMCAcquisitionFunction(
+                self.model,
+                acq,
+                self._get_constraint_callables(),
+                sampler=self._get_sampler(self.model),
+            )
         bounds = self._get_bounds()
 
         if self.fixed_features is not None:

--- a/xopt/generators/bayesian/bayesian_generator.py
+++ b/xopt/generators/bayesian/bayesian_generator.py
@@ -719,9 +719,11 @@ class BayesianGenerator(Generator, ABC):
             columns = []
             values = []
             for name, value in self.fixed_features.items():
-                columns += [self.model_input_names.index(name)]
-                values += [value]
+                columns.append(self.model_input_names.index(name))
+                values.append(value)
 
+            # necessary because fixed feature acq must get tensor - it searches for dtype/device
+            values = torch.tensor(values).to(**self.tkwargs)
             acq = FixedFeatureAcquisitionFunction(
                 acq_function=acq, d=dim, columns=columns, values=values
             )

--- a/xopt/tests/generators/bayesian/test_upper_confidence_bound.py
+++ b/xopt/tests/generators/bayesian/test_upper_confidence_bound.py
@@ -140,8 +140,10 @@ class TestUpperConfidenceBoundGenerator:
         assert candidate["p"] == 3
 
         check_generator_tensor_locations(gen, device_map[use_cuda])
+        gen.get_optimum()
 
         # test with fixed feature in vocs
+        data = deepcopy(TEST_VOCS_DATA)
         gen = UpperConfidenceBoundGenerator(vocs=TEST_VOCS_BASE)
         gen.fixed_features = {"x1": 3.0}
         set_options(gen, use_cuda)
@@ -151,6 +153,7 @@ class TestUpperConfidenceBoundGenerator:
         assert candidate["x1"] == 3
 
         check_generator_tensor_locations(gen, device_map[use_cuda])
+        gen.get_optimum()
 
     def test_constraints_warning(self):
         with pytest.warns(UserWarning):


### PR DESCRIPTION
Wrong bounds and unwrapped acquisition functions were used in the optimum search, causing issues. Fixed and adjusted bounds calc to use better indexing.

Fixes #313 