### PR TITLE
fixed AsynchronousXopt.to_json() and dump

### DIFF
--- a/xopt/asynchronous.py
+++ b/xopt/asynchronous.py
@@ -145,6 +145,10 @@ class AsynchronousXopt(Xopt):
 
         self.add_data(new_data)
 
+        # Dump data to file if specified
+        if self.dump_file is not None:
+            self.dump()
+
         # Cleanup
         self._input_data.drop(index, inplace=True)
 

--- a/xopt/base.py
+++ b/xopt/base.py
@@ -382,8 +382,7 @@ class Xopt(XoptBaseModel):
             new_data.index = np.arange(len(self.data), len(self.data) + len(new_data))
             self.data = pd.concat([self.data, new_data], axis=0)
         else:
-            if new_data.index.dtype != np.int64:
-                new_data.index = new_data.index.astype(np.int64)
+            new_data.index = np.arange(0, len(new_data))
             self.data = new_data
         self.generator.add_data(new_data)
 


### PR DESCRIPTION
I put in a fix for #234 and #235

The error is caused by duplicate indices in  `AsynchronousXopt.data`.

When adding new data, `Xopt.add_data()` checks if `self.data` exists. If this is the first batch of data, keep the indices. If there are already data, reindex the new data and concatenate.
https://github.com/xopt-org/Xopt/blob/7dc1b5c003dded6cde87bd61f965c3185be8ceeb/xopt/base.py#L379-L388

`new_data.index` starts from 0 in `Xopt`, however, in `AsynchronousXopt` it start from 1! This causes `AsynchronousXopt.data` to have two entries with index 1.

This index shift traces down to `AsynchronousXopt.prepare_input_data()`
https://github.com/xopt-org/Xopt/blob/7dc1b5c003dded6cde87bd61f965c3185be8ceeb/xopt/asynchronous.py#L77-L80

It's not clear to me if this shift is required to manage futures. So my proposal is simply forcing `Xopt.add_data()` to always reindex the first batch to start from 0.