### PR TITLE
BO uncertainty constraints and other tweaks for safety-critical scenarios

### DIFF
--- a/xopt/generators/bayesian/bayesian_generator.py
+++ b/xopt/generators/bayesian/bayesian_generator.py
@@ -527,7 +527,7 @@ class BayesianGenerator(Generator, ABC):
         """
         return torch.tensor(data[self.model_input_names].to_numpy(), **self.tkwargs)
 
-    def get_acquisition(self, model: Module) -> AcquisitionFunction:
+    def get_acquisition(self, model: Model) -> AcquisitionFunction:
         """
         Define the acquisition function based on the given GP model.
 
@@ -535,7 +535,7 @@ class BayesianGenerator(Generator, ABC):
 
         Parameters
         ----------
-        model : Module
+        model : Model
             The BoTorch model to be used for generating the acquisition function.
 
         Returns
@@ -684,7 +684,7 @@ class BayesianGenerator(Generator, ABC):
         return sampler
 
     @abstractmethod
-    def _get_acquisition(self, model):
+    def _get_acquisition(self, model: Model):
         pass
 
     def _get_objective(self):

--- a/xopt/generators/bayesian/custom_botorch/noise_constrained_acq.py
+++ b/xopt/generators/bayesian/custom_botorch/noise_constrained_acq.py
@@ -35,7 +35,7 @@ class UncertaintyConstrainedAcquisitionFunction(SampleReducingMCAcquisitionFunct
         constraints: list[Callable[[Tensor], Tensor]] | None = None,
         eta: Tensor | float = 1e-3,
         fat: list[bool | None] | bool = False,
-        variance_limit: dict[int, float] = None,
+        variance_limits: dict[int, float] = None,
         variance_eta: float | dict[int, float] = None,
         variance_min_mult: float | dict[int, float] = 1e-3,
         variance_normalize: bool | dict[int, bool] = False,
@@ -52,31 +52,31 @@ class UncertaintyConstrainedAcquisitionFunction(SampleReducingMCAcquisitionFunct
             eta,
             fat,
         )
-        self.variance_limit = variance_limit
-        if variance_limit is None:
+        self.variance_limit = variance_limits
+        if variance_limits is None:
             assert variance_eta is None, (
                 "If no variance limit is provided, variance_eta must also be None."
             )
 
         if isinstance(variance_eta, float):
-            variance_eta = {k: variance_eta for k in variance_limit.keys()}
+            variance_eta = {k: variance_eta for k in variance_limits.keys()}
         else:
             assert isinstance(variance_eta, dict)
-            assert set(variance_eta.keys()) == set(variance_limit.keys())
+            assert set(variance_eta.keys()) == set(variance_limits.keys())
         self._variance_eta = variance_eta
 
         if isinstance(variance_min_mult, float):
-            variance_min_mult = {k: variance_min_mult for k in variance_limit.keys()}
+            variance_min_mult = {k: variance_min_mult for k in variance_limits.keys()}
         else:
             assert isinstance(variance_min_mult, dict)
-            assert set(variance_min_mult.keys()) == set(variance_limit.keys())
+            assert set(variance_min_mult.keys()) == set(variance_limits.keys())
         self._variance_min_mult = variance_min_mult
 
         if isinstance(variance_normalize, bool):
-            variance_normalize = {k: variance_normalize for k in variance_limit.keys()}
+            variance_normalize = {k: variance_normalize for k in variance_limits.keys()}
         else:
             assert isinstance(variance_normalize, dict)
-            assert set(variance_normalize.keys()) == set(variance_limit.keys())
+            assert set(variance_normalize.keys()) == set(variance_limits.keys())
         self.variance_normalize = variance_normalize
 
     def _non_reduced_forward(self, X: Tensor) -> Tensor:
@@ -214,7 +214,7 @@ class UCqExpectedImprovement(UncertaintyConstrainedAcquisitionFunction):
         X_pending: Tensor | None = None,
         constraints: list[Callable[[Tensor], Tensor]] | None = None,
         eta: Tensor | float = 1e-3,
-        variance_limit: dict[int, float] = None,
+        variance_limits: dict[int, float] = None,
         variance_eta: float | dict[int, float] = None,
         variance_min_mult: float | dict[int, float] = 1e-3,
         variance_normalize: bool | dict[int, bool] = False,
@@ -228,7 +228,7 @@ class UCqExpectedImprovement(UncertaintyConstrainedAcquisitionFunction):
             X_pending=X_pending,
             constraints=constraints,
             eta=eta,
-            variance_limit=variance_limit,
+            variance_limits=variance_limits,
             variance_eta=variance_eta,
             variance_min_mult=variance_min_mult,
             variance_normalize=variance_normalize,
@@ -249,7 +249,7 @@ class UCqPosteriorVariance(UncertaintyConstrainedAcquisitionFunction):
         X_pending: Tensor | None = None,
         constraints: list[Callable[[Tensor], Tensor]] | None = None,
         eta: Tensor | float = 1e-3,
-        variance_limit: dict[int, float] = None,
+        variance_limits: dict[int, float] = None,
         variance_eta: float | dict[int, float] = None,
         variance_min_mult: float | dict[int, float] = 1e-3,
         variance_normalize: bool | dict[int, bool] = False,
@@ -262,7 +262,7 @@ class UCqPosteriorVariance(UncertaintyConstrainedAcquisitionFunction):
             X_pending=X_pending,
             constraints=constraints,
             eta=eta,
-            variance_limit=variance_limit,
+            variance_limits=variance_limits,
             variance_eta=variance_eta,
             variance_min_mult=variance_min_mult,
             variance_normalize=variance_normalize,

--- a/xopt/tests/generators/bayesian/test_noise_constraints.py
+++ b/xopt/tests/generators/bayesian/test_noise_constraints.py
@@ -1,0 +1,49 @@
+import logging
+from copy import deepcopy
+
+import pytest
+import torch
+
+from xopt.generators.bayesian import ExpectedImprovementGenerator
+from xopt.generators.bayesian.custom_botorch.noise_constrained_acq import (
+    UCqExpectedImprovement,
+)
+from xopt.resources.testing import (
+    TEST_VOCS_BASE,
+    TEST_VOCS_DATA,
+    check_generator_tensor_locations,
+    create_set_options_helper,
+    generate_without_warnings,
+)
+
+set_options = create_set_options_helper(data=TEST_VOCS_DATA)
+device_map = {False: torch.device("cpu"), True: torch.device("cuda:0")}
+
+logger = logging.getLogger(__name__)
+
+use_cuda = False
+
+
+@pytest.mark.parametrize("turbo", [None])
+@pytest.mark.parametrize("log", [False])
+def test_ei_nc(log, turbo):
+    # logger.info(f"Running test for {problem_cfg} with log {log} and turbo {turbo}")
+
+    vocs = deepcopy(TEST_VOCS_BASE)
+    vocs.constraints = {}
+    gen = ExpectedImprovementGenerator(
+        vocs=vocs,
+        variance_limits={vocs.objective_names[0]: 0.1},
+        variance_eta={vocs.objective_names[0]: 0.001},
+    )
+    set_options(gen, use_cuda=False, add_data=True)
+
+    candidate = generate_without_warnings(gen, 1)
+    assert len(candidate) == 1
+
+    candidate = generate_without_warnings(gen, 2)
+    assert len(candidate) == 2
+
+    check_generator_tensor_locations(gen, device_map[use_cuda])
+
+    assert isinstance(gen.get_acquisition(gen.model), UCqExpectedImprovement)


### PR DESCRIPTION
This is the PR implementing new techniques used in recent FNAL Booster studies to ensure safety-critical pessimistic exploration. It adds constraints based on GP uncertainty, effectively penalizing regions that lack nearby samples. 

Depending on how it is combined with noise priors, noise limits, and other fitting configs, the behavior of these constraints changes drastically from no impact to a very strong enforcement of local sampling. Care must be taken to ensure inferred and experimental noise levels are reasonable relative to constraint levels. We should expose the advanced config options but set defaults to something sane, like the 'untransformed absolute noise level'. This config can be worded as 'only sample where objective uncertainty < +-x', and has intuitive experimental interpretation.

While in theory universally compatible just like regular constraints, for some acquisition functions a special implementation that reuses computations can be faster (at cost of extra code).

This PR will provide core implementation, a debug notebook, and some visualization helpers. For now, config will be stored as generator field and not in VOCS, because only a few methods can provide uncertainty quantification.