### PR TITLE
Fix `NSGA2Generator` Example Notebook Stats Output

### DIFF
--- a/docs/examples/ga/nsga2/nsga2_python.ipynb
+++ b/docs/examples/ga/nsga2/nsga2_python.ipynb
@@ -98,10 +98,10 @@
    "source": [
     "# Run the optimizer for a few generations. Notice log output printed below this cell\n",
     "ev.max_workers = generator.population_size\n",
-    "X = Xopt(generator=generator, evaluator=ev, vocs=prob_vocs)\n",
+    "my_xopt = Xopt(generator=generator, evaluator=ev, vocs=prob_vocs)\n",
     "\n",
     "for _ in range(3):\n",
-    "    X.step()"
+    "    my_xopt.step()"
    ]
   },
   {
@@ -124,7 +124,7 @@
     "    logging.root.removeHandler(handler)\n",
     "\n",
     "for _ in range(47):\n",
-    "    X.step()"
+    "    my_xopt.step()"
    ]
   },
   {
@@ -135,13 +135,13 @@
    "source": [
     "# Inspect generator properties\n",
     "print(\n",
-    "    f\"Saw {generator.fevals} function evaluations\"\n",
+    "    f\"Saw {my_xopt.generator.fevals} function evaluations\"\n",
     ")  # Number of function evaluations returned to generator\n",
     "print(\n",
-    "    f\"Completed {generator.n_generations} generations\"\n",
+    "    f\"Completed {my_xopt.generator.n_generations} generations\"\n",
     ")  # Number of generations finished\n",
     "print(\n",
-    "    f\"Generated {generator.n_candidates} candidate solutions\"\n",
+    "    f\"Generated {my_xopt.generator.n_candidates} candidate solutions\"\n",
     ")  # Number of individuals generated"
    ]
   },
@@ -156,7 +156,7 @@
     "# unique index for indviduals.\n",
     "#\n",
     "# NOTE: The data DataFrame is not stored when serializing the generator. It must be saved on its own for later use.\n",
-    "X.generator.data.head()"
+    "my_xopt.generator.data.head()"
    ]
   },
   {
@@ -166,12 +166,14 @@
    "outputs": [],
    "source": [
     "# Each population the optimizer has seen is stored by the unique indices of each individual.\n",
-    "print(X.generator.history_idx[-1][:16])  # Show the first few indices of last generation\n",
+    "print(\n",
+    "    my_xopt.generator.history_idx[-1][:16]\n",
+    ")  # Show the first few indices of last generation\n",
     "\n",
     "# If you have the data DataFrame you can extract all variables, objectives, constraints for each population\n",
     "# Get a DataFrame of all information for the first population with every row being an individual\n",
-    "X.generator.data[\n",
-    "    X.generator.data[\"xopt_candidate_idx\"].isin(X.generator.history_idx[0])\n",
+    "my_xopt.generator.data[\n",
+    "    my_xopt.generator.data[\"xopt_candidate_idx\"].isin(my_xopt.generator.history_idx[0])\n",
     "].head()"
    ]
   },
@@ -182,13 +184,13 @@
    "outputs": [],
    "source": [
     "# Using the population records we can plot the final generation's objective functions\n",
-    "final_pop = X.generator.data[\n",
-    "    X.generator.data[\"xopt_candidate_idx\"].isin(X.generator.history_idx[-1])\n",
+    "final_pop = my_xopt.generator.data[\n",
+    "    my_xopt.generator.data[\"xopt_candidate_idx\"].isin(my_xopt.generator.history_idx[-1])\n",
     "]\n",
     "plt.scatter(final_pop[\"f1\"], final_pop[\"f2\"])\n",
     "plt.xlabel(\"f1\")\n",
     "plt.ylabel(\"f2\")\n",
-    "plt.title(f\"ZDT3, Generation {X.generator.n_generations}\")"
+    "plt.title(f\"ZDT3, Generation {my_xopt.generator.n_generations}\")"
    ]
   },
   {
@@ -235,9 +237,9 @@
     "\n",
     "# Run it for a couple of generations\n",
     "ev.max_workers = generator.population_size\n",
-    "X = Xopt(generator=generator, evaluator=ev, vocs=prob_vocs)\n",
+    "my_xopt = Xopt(generator=generator, evaluator=ev, vocs=prob_vocs)\n",
     "for _ in range(32):\n",
-    "    X.step()"
+    "    my_xopt.step()"
    ]
   },
   {
@@ -260,20 +262,20 @@
    "source": [
     "# In the event data was already written to `output_dir` the generator will choose a new path with a numeric suffix\n",
     "# to avoid overwriting anything.\n",
-    "X = Xopt(\n",
+    "my_xoptX = Xopt(\n",
     "    generator=NSGA2Generator(vocs=prob_vocs, output_dir=output_dir),\n",
     "    evaluator=ev,\n",
     "    vocs=prob_vocs,\n",
     ")\n",
     "for _ in range(32):\n",
-    "    X.step()\n",
+    "    my_xopt.step()\n",
     "\n",
     "# Compare the requested path and where the data ended up\n",
     "print(f'Requested path: \"{output_dir}\"')\n",
-    "print(f'Path used:      \"{X.generator.output_dir}\"')\n",
+    "print(f'Path used:      \"{my_xopt.generator.output_dir}\"')\n",
     "\n",
     "# Clean up the directory\n",
-    "X.generator.close_log_file()"
+    "my_xopt.generator.close_log_file()"
    ]
   },
   {
@@ -283,7 +285,7 @@
    "outputs": [],
    "source": [
     "# Load all data back in\n",
-    "df = pd.read_csv(os.path.join(X.generator.output_dir, \"data.csv\"))\n",
+    "df = pd.read_csv(os.path.join(my_xopt.generator.output_dir, \"data.csv\"))\n",
     "df.head()"
    ]
   },
@@ -294,7 +296,7 @@
    "outputs": [],
    "source": [
     "# Read the VOCS object back in. This can be used for data analysis / restarting optimizations\n",
-    "with open(os.path.join(X.generator.output_dir, \"vocs.txt\")) as f:\n",
+    "with open(os.path.join(my_xopt.generator.output_dir, \"vocs.txt\")) as f:\n",
     "    vocs_from_file = VOCS.from_dict(json.load(f))\n",
     "\n",
     "# Show the objectives\n",
@@ -308,7 +310,7 @@
    "outputs": [],
    "source": [
     "# Load the populations and get just the last population\n",
-    "df = pd.read_csv(os.path.join(X.generator.output_dir, \"populations.csv\"))\n",
+    "df = pd.read_csv(os.path.join(my_xopt.generator.output_dir, \"populations.csv\"))\n",
     "last_pop = df[df[\"xopt_generation\"] == df[\"xopt_generation\"].max()]\n",
     "last_pop.head()"
    ]
@@ -324,14 +326,14 @@
     "restored_generator = NSGA2Generator(checkpoint_file=last_checkpoint)\n",
     "\n",
     "# Demonstrate using the generator after loading (starting optimization from its last saved point)\n",
-    "X = Xopt(generator=restored_generator, evaluator=ev, vocs=prob_vocs)\n",
+    "restored_xopt = Xopt(generator=restored_generator, evaluator=ev, vocs=prob_vocs)\n",
     "for _ in range(32):\n",
-    "    X.step()\n",
+    "    restored_xopt.step()\n",
     "print(f\"Further optimization: {restored_generator}\")\n",
     "\n",
     "# Clean up the output\n",
-    "X.generator.close_log_file()\n",
-    "shutil.rmtree(X.generator.output_dir)"
+    "restored_xopt.generator.close_log_file()\n",
+    "shutil.rmtree(restored_xopt.generator.output_dir)"
    ]
   },
   {
@@ -341,7 +343,7 @@
    "outputs": [],
    "source": [
     "# Clean up the original output\n",
-    "X.generator.close_log_file()"
+    "my_xopt.generator.close_log_file()"
    ]
   },
   {


### PR DESCRIPTION
Fix the block of the `NSGA2Generator` notebook which displays `generator.fevals` etc. after running an optimization. Generators are deep copied now and this broke the display. This PR changes the notebook to show the value from the `Xopt` object instead to fix it. I also use different names for the main `Xopt` objects and the one restored from checkpoint.