### PR TITLE
Ensemble Models

### DIFF
--- a/xopt/generators/bayesian/bax/acquisition.py
+++ b/xopt/generators/bayesian/bax/acquisition.py
@@ -125,5 +125,8 @@ class ModelListExpectedInformationGain(MultiObjectiveAnalyticAcquisitionFunction
         # eq (4) of https://arxiv.org/pdf/2104.09460.pdf
         # (avg_h_fantasy is a Monte-Carlo estimate of the second term on the right)
         eig = h_current_scalar - avg_h_fantasy
+        
+        # mean over properties
+        eig = eig.mean(dim=-1, keepdim=True)
 
         return eig.reshape(X.shape[:-2])

--- a/xopt/generators/bayesian/bax/acquisition.py
+++ b/xopt/generators/bayesian/bax/acquisition.py
@@ -39,7 +39,8 @@ class ModelListExpectedInformationGain(MultiObjectiveAnalyticAcquisitionFunction
 
 
         # Need to call the model on some data before we can condition_on_observations
-       # self.model.posterior(*[self.xs_exe[:1, 0:1, 0:] for m in model.models])
+        # SG: removed this -- I don't think it's needed?
+        # self.model.posterior(*[self.xs_exe[:1, 0:1, 0:] for m in model.models])
 
         # construct a batch of size n_samples fantasy models,
         # where each fantasy model is produced by taking the model

--- a/xopt/generators/bayesian/bax/acquisition.py
+++ b/xopt/generators/bayesian/bax/acquisition.py
@@ -39,7 +39,7 @@ class ModelListExpectedInformationGain(MultiObjectiveAnalyticAcquisitionFunction
 
 
         # Need to call the model on some data before we can condition_on_observations
-        self.model.posterior(*[self.xs_exe[:1, 0:1, 0:] for m in model.models])
+       # self.model.posterior(*[self.xs_exe[:1, 0:1, 0:] for m in model.models])
 
         # construct a batch of size n_samples fantasy models,
         # where each fantasy model is produced by taking the model

--- a/xopt/generators/bayesian/models/ensemble.py
+++ b/xopt/generators/bayesian/models/ensemble.py
@@ -166,6 +166,7 @@ class MCDropoutModel(Model):
             y_s = y
         
         optimizer = optim_type(self.model.parameters(), lr=lr)
+
         
         for epoch in range(n_epochs):
             pred = self.model(X_s)
@@ -226,8 +227,12 @@ class MCDropoutModel(Model):
 
     def posterior(self, X: Tensor, **kwargs):
         samples = self.forward(X)
+        if hasattr(self, "outcome_transform"):
+            samples = self.outcome_transform.untransform(samples)[0]
+            
+        posterior = FlattenedEnsemblePosterior(samples)
 
-        return FlattenedEnsemblePosterior(samples)
+        return posterior
     
     def set_train_data(self, X = None, y = None, strict=False):
         if X is None or y is None:

--- a/xopt/generators/bayesian/models/ensemble.py
+++ b/xopt/generators/bayesian/models/ensemble.py
@@ -1,0 +1,236 @@
+from botorch.models.model import Model, ModelList
+from botorch.models.transforms import Normalize, Standardize
+from botorch.posteriors.ensemble import EnsemblePosterior
+
+from gpytorch.distributions import MultivariateNormal
+
+import torch
+from torch import Tensor
+from torch import nn
+
+import numpy as np
+from copy import deepcopy
+
+from xopt.generators.bayesian.base_model import ModelConstructor
+from xopt.generators.bayesian.utils import get_training_data
+
+from pydantic import Field
+from typing import List, Callable, Dict, Union
+import pandas as pd
+
+
+class EnsembleModelConstructor(ModelConstructor):
+    """
+    Model constructor for ensemble estimates
+    """
+    name: str = Field("ensemble")
+    model: Callable = Field(None, description="Ensemble model")
+        
+    def build_model(
+        self,
+        input_names: List[str],
+        outcome_names: List[str],
+        data: pd.DataFrame,
+        input_bounds: Dict[str, List] = None,
+        dtype: torch.dtype = torch.float64,
+        device: Union[torch.device, str] = "cpu",
+    ):
+        # get training data -- need to update utils for multivariate case
+        train_X, train_Y, train_Yvar = get_training_data(
+            input_names, outcome_names[0], data
+        )
+        self.model = self.model.to(dtype)
+        
+        self.model.fit(train_X, train_Y)
+        self.model = self.model.to(device)
+        self.model.eval()
+        
+        self.model.models = [self.model]
+        
+        return self.model
+
+class MCDropoutMLP(nn.Module):
+    """
+    Generic multi-layer perceptron model with MC dropout
+    """
+    def __init__(self, input_dim, output_dim, dropout_rate=0.5, n_hidden_layers=3, hidden_dim=100, 
+                 hidden_activation=nn.ReLU(), output_activation=None):
+        super().__init__()
+
+        self.layers = nn.ModuleList()
+        for i in range(n_hidden_layers):
+            if i == 0:
+                self.layers.append(nn.Linear(input_dim, hidden_dim))
+            else:
+                self.layers.append(nn.Linear(hidden_dim, hidden_dim))
+                
+            self.layers.append(nn.Dropout(p=dropout_rate))
+            self.layers.append(hidden_activation)
+
+        
+        if n_hidden_layers == 0:
+            self.layers.append(nn.Linear(input_dim, output_dim))
+        else:
+            self.layers.append(nn.Linear(hidden_dim, output_dim))
+
+        if output_activation is not None:
+            self.layers.append(output_activation)
+
+    def forward(self, input_data, seed=None):
+        # Needed so that dropout works
+        self.train()
+        if seed is not None:
+            torch.random.manual_seed(seed)
+        for layer in self.layers:
+            input_data = layer(input_data)
+            
+        self.eval()
+        return input_data
+
+
+class FlattenedEnsemblePosterior(EnsemblePosterior):
+    """
+    Wrapper for EnsemblePosterior to make shapes do similar things
+    as GPyTorchPosterior. 
+    """
+    def rsample(self, sample_shape=torch.Size()):
+        samples = super().rsample(sample_shape)
+        # Flatten (q, m) into a single dimension like GP case
+        q, m = samples.shape[-2:]
+        return samples.view(*samples.shape[:-2], q * m)
+    
+    @property
+    def mean(self):
+        # Average over ensemble dimension
+        return super().mean.mean(dim=1)
+    
+    @property
+    def variance(self):
+        # Average over ensemble dimension
+        return super().variance.mean(dim=1)
+    
+    @property
+    def mvn(self):
+        mean = self.mean
+        variance = self.variance
+        
+        # Assumes diagonal gaussian for simplicity
+        covar = torch.diag_embed(variance.squeeze(-1).squeeze(-1))
+        mvn = MultivariateNormal(mean.squeeze(-1).squeeze(-1), covariance_matrix=covar)
+        
+        return mvn
+        
+
+class MCDropoutModel(Model):
+    """
+    BoTorch model for MC dropout ensemble
+    """
+    
+    model: MCDropoutMLP
+    num_samples: int
+    input_dim: int
+    output_dim: int
+    dropout_rate: float
+    n_hidden_layers: int
+    hidden_dim: int
+
+    def __init__(self, input_dim: int, output_dim: int, dropout_rate: float = 0.1, 
+                 num_samples: int = 30, n_hidden_layers=3, hidden_dim=100, 
+                 hidden_activation=nn.ReLU(), output_activation=None, observables=['y1'],
+                input_bounds=torch.tensor([[-np.pi], [np.pi]])):
+        
+        super(MCDropoutModel, self).__init__()
+        self.model = MCDropoutMLP(input_dim, output_dim, 
+                                    dropout_rate=dropout_rate,
+                                    n_hidden_layers=n_hidden_layers, 
+                                    hidden_dim=hidden_dim, 
+                                    hidden_activation=hidden_activation, 
+                                    output_activation=output_activation)
+        
+        self.num_samples = num_samples
+        
+        self.outcome_transform = Standardize(output_dim)
+        self.input_transform = Normalize(input_dim, bounds = input_bounds)
+        self.output_indices = None
+
+    def fit(self, X: Tensor, y: Tensor, loss_fn=torch.nn.MSELoss(),
+            n_epochs = 500, optim_type = torch.optim.Adam, lr = 1e-3, is_fantasy=False) -> None:
+        
+        self.model.train()
+        # Seems like this is normalized already in InfoBAX calc?
+        if not is_fantasy:
+            X_s = self.input_transform(X)
+            y_s = self.outcome_transform(y)[0]
+        else:
+            X_s = X
+            y_s = y
+        
+        optimizer = optim_type(self.model.parameters(), lr=lr)
+        
+        for epoch in range(n_epochs):
+            pred = self.model(X_s)
+            loss = loss_fn(pred, y_s)
+            
+            optimizer.zero_grad()
+            loss.backward()
+            optimizer.step()
+            
+        
+            self.train_inputs = (X,)
+            self.train_targets = y
+            
+  
+    def condition_on_observations(self, X, y, n_cond_epochs=40):
+        fantasies = []
+        for i_batch in range(X.shape[0]):
+            new_model = deepcopy(self)
+            train_X = torch.cat([new_model.train_inputs[0], X[i_batch]], dim=0)
+            train_y = torch.cat([new_model.train_targets, y[i_batch]], dim=0)
+            
+            new_model.fit(train_X, train_y, n_epochs=n_cond_epochs, is_fantasy=True)
+            
+            fantasies.append(new_model)
+            
+        return ModelList(*fantasies)
+    
+    def subset_output(self, output_indices):
+        # Create a deep copy of the model to avoid modifying the original
+        new_model = deepcopy(self)
+        new_model.output_indices = output_indices
+
+        return new_model
+        
+
+    def forward(self, X: Tensor) -> Tensor:
+        x = self.input_transform(X)
+        
+        preds = []
+        for i in range(self.num_samples):
+            out = self.model(x, seed=i)
+            # Some of this shape logic to be checked -- probably need to modify for n-d
+            if out.ndim == 2:
+                out = out.unsqueeze(-1)
+            elif out.ndim == 1:
+                out = out.unsqueeze(-1).unsqueeze(-1)
+                
+            out = out.unsqueeze(1)  
+            preds.append(out)
+
+        samples = torch.cat(preds, dim=1)
+
+        if self.output_indices is not None:
+            return samples[..., self.output_indices]
+        else:
+            return samples
+    
+
+    def posterior(self, X: Tensor, **kwargs):
+        samples = self.forward(X)
+
+        return FlattenedEnsemblePosterior(samples)
+    
+    def set_train_data(self, X = None, y = None, strict=False):
+        if X is None or y is None:
+            return
+        self.train_inputs = (X,)
+        self.train_targets = y

--- a/xopt/generators/bayesian/models/ensemble.py
+++ b/xopt/generators/bayesian/models/ensemble.py
@@ -37,7 +37,7 @@ class EnsembleModelConstructor(ModelConstructor):
     ):
         # get training data -- need to update utils for multivariate case
         train_X, train_Y, train_Yvar = get_training_data(
-            input_names, outcome_names[0], data
+            input_names, outcome_names, data
         )
         self.model = self.model.to(dtype)
         
@@ -213,9 +213,8 @@ class MCDropoutModel(Model):
         preds = []
         for i in range(self.num_samples):
             out = self.model(x, seed=i)
-            # Some of this shape logic to be checked -- probably need to modify for n-d
-            if out.ndim == 2:
-                out = out.unsqueeze(-1)
+            if out.ndim == 2: # add q dimension
+                out = out.unsqueeze(-2)
             elif out.ndim == 1:
                 out = out.unsqueeze(-1).unsqueeze(-1)
                 

--- a/xopt/generators/bayesian/utils.py
+++ b/xopt/generators/bayesian/utils.py
@@ -1,5 +1,5 @@
 from copy import deepcopy
-from typing import List
+from typing import List, Union
 
 import numpy as np
 import pandas as pd
@@ -9,7 +9,7 @@ from xopt.vocs import VOCS
 
 
 def get_training_data(
-    input_names: List[str], outcome_names: str, data: pd.DataFrame
+    input_names: List[str], outcome_names: Union[str, List[str]], data: pd.DataFrame
 ) -> (torch.Tensor, torch.Tensor):
     """
     Creates training data from input data frame.
@@ -43,6 +43,9 @@ def get_training_data(
 
     """
 
+    if type(outcome_names) != list:
+        outcome_names = [outcome_names]
+        
     input_data = data[input_names]
     outcome_data = data[outcome_names]
 

--- a/xopt/generators/bayesian/utils.py
+++ b/xopt/generators/bayesian/utils.py
@@ -9,7 +9,7 @@ from xopt.vocs import VOCS
 
 
 def get_training_data(
-    input_names: List[str], outcome_name: str, data: pd.DataFrame
+    input_names: List[str], outcome_names: str, data: pd.DataFrame
 ) -> (torch.Tensor, torch.Tensor):
     """
     Creates training data from input data frame.
@@ -44,23 +44,26 @@ def get_training_data(
     """
 
     input_data = data[input_names]
-    outcome_data = data[outcome_name]
+    outcome_data = data[outcome_names]
 
     # cannot use any rows where any variable values are nans
     non_nans = ~input_data.isnull().T.any()
     input_data = input_data[non_nans]
     outcome_data = outcome_data[non_nans]
 
-    train_X = torch.tensor(input_data[~outcome_data.isnull()].to_numpy(dtype="double"))
+    train_X = torch.tensor(input_data[~outcome_data.isnull().T.any()].to_numpy(dtype="double"))
     train_Y = torch.tensor(
-        outcome_data[~outcome_data.isnull()].to_numpy(dtype="double")
-    ).unsqueeze(-1)
+        outcome_data[~outcome_data.isnull().T.any()].to_numpy(dtype="double")
+    )
+    if train_Y.ndim < 2:
+        train_Y = train_Y.unsqueeze(-1)
 
     train_Yvar = None
-    if f"{outcome_name}_var" in data:
-        variance_data = data[f"{outcome_name}_var"][non_nans]
+    var_names = [f"{name}_var" for name in outcome_names if f"{name}_var" in data]
+    if len(var_names) > 0:
+        variance_data = data[var_names][non_nans]
         train_Yvar = torch.tensor(
-            variance_data[~outcome_data.isnull()].to_numpy(dtype="double")
+            variance_data[~outcome_data.isnull().T.any()].to_numpy(dtype="double")
         ).unsqueeze(-1)
 
     return train_X, train_Y, train_Yvar


### PR DESCRIPTION
Add model constructor and pipelining for ensemble models using BoTorch EnsembleModel. Implementation here for an MCDropout NN ensemble, but should be generalizable for proper NN ensemble, or even random forests. Focused on BAX here. 

NB: generally standalone, `get_training_data` is main difference without explicitly separate logic. See https://github.com/xopt-org/bax_algorithms/pull/3 for an example.