### PR TITLE
Add codecov upload

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,5 +32,10 @@ jobs:
         shell: bash -l {0}
         run: |
           echo -e '## Test results\n\n```' >> "$GITHUB_STEP_SUMMARY"
-          pytest xopt/tests -v 2>&1 | tee -a "$GITHUB_STEP_SUMMARY"
+          pytest xopt/tests -v --cov=xopt --cov-report=term --cov-report=xml 2>&1 | tee -a "$GITHUB_STEP_SUMMARY"
           echo '```' >> "$GITHUB_STEP_SUMMARY"
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          slug: xopt-org/xopt


### PR DESCRIPTION
Add upload of codecov report to codecov. Requires repo setup + adding an auth token to the repo secrets at the moment.

Note that this will not fail the CI if upload fails. We can set it to do that if we disable token authentication so anyone can upload. 