### PR TITLE
Produce wheels for pypi

### DIFF
--- a/.github/workflows/pypi_upload.yml
+++ b/.github/workflows/pypi_upload.yml
@@ -24,11 +24,10 @@ jobs:
           pip install
           build
           --user
-      - name: Build a source tarball
+      - name: Build a source tarball and wheel
         run: >-
           python -m
           build
-          --sdist
           --outdir dist/
           .
       - name: Publish distribution to PyPI


### PR DESCRIPTION
Users installing Xopt in environments that use `--no-build-isolation` (or without `setuptools_scm` pre-installed) would see:
```
This happened because the PyPI release only included a source distribution (.tar.gz). When pip downloaded it and ran the build backend to extract metadata, setuptools_scm was unavailable in the build environment, causing the version to fall back to 0.0.0. pip then rejected the package as inconsistent with the requested version.
```

This PR removes `--sdist` from the `python -m build` call. Without this flag, `python -m build` produces both the sdist and a pure-Python wheel (py3-none-any) by default. When a wheel is present on PyPI, pip uses it directly without invoking the build backend at all, completely bypassing the `setuptools_scm` version resolution.

No change to the sdist, source-based installs and downstream packagers (conda-forge) are unaffected

Applies to all future releases; 3.0.1 on PyPI remains broken and should be yanked or wheels uploaded manually.