### PR TITLE
reference point improvements

### DIFF
--- a/xopt/generators/bayesian/visualize.py
+++ b/xopt/generators/bayesian/visualize.py
@@ -22,8 +22,9 @@ from matplotlib.figure import Figure
 from matplotlib.axes import Axes
 from matplotlib.ticker import FormatStrFormatter
 
+from xopt.errors import FeasibilityError
 from xopt.generator import Generator
-from xopt.vocs import VOCS, get_feasibility_data
+from xopt.vocs import VOCS, get_feasibility_data, select_best
 
 from .objectives import feasibility
 from .utils import torch_compile_gp_model, torch_trace_gp_model
@@ -148,10 +149,12 @@ def visualize_model(
         Defaults to vocs.variable_names.
     idx : int
         Index of the last sample to use. This also selects the point of reference in
-        higher dimensions unless an explicit reference_point is given.
+        higher dimensions when the reference point cannot be inferred from
+        :func:`xopt.vocs.select_best` and no explicit reference_point is given.
     reference_point : dict
         Reference point determining the value of variables in vocs.variable_names, but not in variable_names
-        (slice plots in higher dimensions). Defaults to last used sample.
+        (slice plots in higher dimensions). Defaults to the current best feasible point
+        from :func:`xopt.vocs.select_best` when available, otherwise to the sample at idx.
     show_samples : bool, optional
         Whether samples are shown.
     show_prior_mean : bool, optional
@@ -1090,7 +1093,10 @@ def _get_reference_point(
 ) -> dict[str, Any]:
     """Returns a valid reference point.
 
-    If the given reference point is None, the data sample corresponding to the given index is used.
+    If the given reference point is None, the best feasible point from
+    :func:`xopt.vocs.select_best` is used when available. If this is not possible
+    (e.g., multi-objective problem or no feasible points), the data sample
+    corresponding to the given index is used.
 
     Parameters
     ----------
@@ -1101,7 +1107,7 @@ def _get_reference_point(
     data : DataFrame
         Data used to select a reference point.
     idx : int, optional
-        Index of the sample to use as a reference point.
+        Index of the sample to use as a fallback reference point.
 
     Returns
     -------
@@ -1110,7 +1116,11 @@ def _get_reference_point(
     """
     if reference_point is not None:
         return reference_point
-    else:
+
+    try:
+        _, _, best_point = select_best(vocs, data)
+        return best_point
+    except (FeasibilityError, NotImplementedError, RuntimeError):
         return data[vocs.variable_names].iloc[idx].to_dict()
 
 

--- a/xopt/generators/bayesian/visualize.py
+++ b/xopt/generators/bayesian/visualize.py
@@ -9,6 +9,7 @@ from typing import (
     TypedDict,
     Union,
 )
+import textwrap
 
 import gpytorch
 import numpy as np
@@ -209,8 +210,10 @@ def visualize_model(
 
     reference_point = _get_reference_point(reference_point, vocs, data, idx)
 
-    figure_title = "Reference point: " + " ".join(
-        [f"{name}: {reference_point[name]:.2}" for name in reference_point_names]
+    figure_title = _format_reference_point_title(
+        reference_point,
+        reference_point_names,
+        fallback_names=vocs.variable_names,
     )
     fig.suptitle(figure_title)
 
@@ -1109,6 +1112,49 @@ def _get_reference_point(
         return reference_point
     else:
         return data[vocs.variable_names].iloc[idx].to_dict()
+
+
+def _format_reference_point_title(
+    reference_point: dict[str, Any],
+    reference_point_names: list[str],
+    fallback_names: Optional[list[str]] = None,
+    max_line_length: int = 90,
+) -> str:
+    """Formats reference-point values into a readable, wrapped figure title."""
+    title_names = reference_point_names or (fallback_names or [])
+    if not title_names:
+        return "Reference point"
+
+    entries = [f"{name}: {reference_point[name]:.2}" for name in title_names]
+    lines: list[str] = []
+    current_line = ""
+
+    for entry in entries:
+        candidate = entry if not current_line else f"{current_line}, {entry}"
+        if len(candidate) <= max_line_length:
+            current_line = candidate
+            continue
+
+        if current_line:
+            lines.append(current_line)
+
+        # Keep very long variable labels readable instead of letting them overflow.
+        wrapped_entry = textwrap.wrap(
+            entry,
+            width=max_line_length,
+            break_long_words=True,
+            break_on_hyphens=False,
+        )
+        if wrapped_entry:
+            lines.extend(wrapped_entry[:-1])
+            current_line = wrapped_entry[-1]
+        else:
+            current_line = entry
+
+    if current_line:
+        lines.append(current_line)
+
+    return "Reference point:\n" + "\n".join(lines)
 
 
 def _get_model_predictions(

--- a/xopt/generators/bayesian/visualize.py
+++ b/xopt/generators/bayesian/visualize.py
@@ -213,12 +213,16 @@ def visualize_model(
 
     reference_point = _get_reference_point(reference_point, vocs, data, idx)
 
-    figure_title = _format_reference_point_title(
-        reference_point,
-        reference_point_names,
-        fallback_names=vocs.variable_names,
-    )
-    fig.suptitle(figure_title)
+    if reference_point_names:
+        figure_title = _format_reference_point_title(
+            reference_point,
+            reference_point_names,
+        )
+        fig.suptitle(figure_title)
+    elif fig._suptitle is not None:
+        # Clear existing title when reusing axes for full-dimensional plots.
+        fig._suptitle.remove()
+        fig._suptitle = None
 
     # create plot
     if dim_x == 1:
@@ -1127,15 +1131,13 @@ def _get_reference_point(
 def _format_reference_point_title(
     reference_point: dict[str, Any],
     reference_point_names: list[str],
-    fallback_names: Optional[list[str]] = None,
     max_line_length: int = 90,
 ) -> str:
     """Formats reference-point values into a readable, wrapped figure title."""
-    title_names = reference_point_names or (fallback_names or [])
-    if not title_names:
+    if not reference_point_names:
         return "Reference point"
 
-    entries = [f"{name}: {reference_point[name]:.2}" for name in title_names]
+    entries = [f"{name}: {reference_point[name]:.2}" for name in reference_point_names]
     lines: list[str] = []
     current_line = ""
 

--- a/xopt/tests/generators/bayesian/test_visualize.py
+++ b/xopt/tests/generators/bayesian/test_visualize.py
@@ -248,6 +248,25 @@ def test_get_reference_point_falls_back_to_idx_for_multi_objective():
     assert ref == {"x": 0.1, "y": 0.2}
 
 
+def test_get_reference_point_falls_back_to_idx_for_explore_objective():
+    vocs = VOCS(
+        variables={"x": [0, 1], "y": [0, 1]},
+        objectives={"z": "EXPLORE"},
+        constraints={},
+        observables=["z"],
+    )
+    data = pd.DataFrame(
+        {
+            "x": [0.1, 0.9],
+            "y": [0.2, 0.8],
+            "z": [1.0, 0.0],
+        }
+    )
+
+    ref = visualize._get_reference_point(None, vocs, data, idx=0)
+    assert ref == {"x": 0.1, "y": 0.2}
+
+
 def test_get_reference_point_falls_back_to_idx_for_no_feasible_points():
     vocs = VOCS(
         variables={"x": [0, 1], "y": [0, 1]},

--- a/xopt/tests/generators/bayesian/test_visualize.py
+++ b/xopt/tests/generators/bayesian/test_visualize.py
@@ -99,6 +99,51 @@ def test_visualize_model(vocs, data, variable_names, show_acquisition):
     )
 
 
+def test_visualize_model_reference_title_visibility(vocs, data):
+    generator = UpperConfidenceBoundGenerator(vocs=vocs)
+    generator.add_data(data)
+    generator.train_model()
+
+    fig, _ = visualize.visualize_model(
+        model=generator.model,
+        vocs=vocs,
+        data=data,
+        tkwargs={},
+        output_names=["z"],
+        variable_names=["x"],
+        n_grid=5,
+        show_acquisition=False,
+    )
+    assert fig._suptitle is not None
+    assert fig._suptitle.get_text().startswith("Reference point:\n")
+
+    fig, ax = visualize.visualize_model(
+        model=generator.model,
+        vocs=vocs,
+        data=data,
+        tkwargs={},
+        output_names=["z"],
+        variable_names=["x", "y"],
+        n_grid=5,
+        show_acquisition=False,
+    )
+    assert fig._suptitle is None
+
+    fig.suptitle("Temporary title")
+    fig, _ = visualize.visualize_model(
+        model=generator.model,
+        vocs=vocs,
+        data=data,
+        tkwargs={},
+        output_names=["z"],
+        variable_names=["x", "y"],
+        n_grid=5,
+        show_acquisition=False,
+        axes=ax,
+    )
+    assert fig._suptitle is None
+
+
 def test_plot_model_prediction_1d(vocs, data):
     model = DummyModel()
     ax = visualize.plot_model_prediction(
@@ -312,18 +357,6 @@ def test_format_reference_point_title_wraps_long_text():
 
     assert title.startswith("Reference point:\n")
     assert title.count("\n") > 1
-
-
-def test_format_reference_point_title_uses_fallback_names():
-    reference_point = {"x": 0.25, "y": 0.75}
-    title = visualize._format_reference_point_title(
-        reference_point,
-        [],
-        fallback_names=["x", "y"],
-    )
-    assert title.startswith("Reference point:\n")
-    assert "x: 0.25" in title
-    assert "y: 0.75" in title
 
 
 def test_format_reference_point_title_empty_without_names():

--- a/xopt/tests/generators/bayesian/test_visualize.py
+++ b/xopt/tests/generators/bayesian/test_visualize.py
@@ -222,6 +222,12 @@ def test_get_reference_point(vocs, data):
     assert ref == {"x": 1.0, "y": 1.0}
 
 
+def test_get_reference_point_returns_explicit_reference(vocs, data):
+    explicit = {"x": 0.123, "y": 0.456}
+    ref = visualize._get_reference_point(explicit, vocs, data)
+    assert ref == explicit
+
+
 def test_get_reference_point_falls_back_to_idx_for_multi_objective():
     vocs = VOCS(
         variables={"x": [0, 1], "y": [0, 1]},
@@ -240,6 +246,36 @@ def test_get_reference_point_falls_back_to_idx_for_multi_objective():
 
     ref = visualize._get_reference_point(None, vocs, data, idx=0)
     assert ref == {"x": 0.1, "y": 0.2}
+
+
+def test_get_reference_point_falls_back_to_idx_for_no_feasible_points():
+    vocs = VOCS(
+        variables={"x": [0, 1], "y": [0, 1]},
+        objectives={"z": "MAXIMIZE"},
+        constraints={"z": ["LESS_THAN", -10.0]},
+        observables=["z"],
+    )
+    data = pd.DataFrame(
+        {
+            "x": [0.2, 0.8],
+            "y": [0.3, 0.9],
+            "z": [0.1, 0.2],
+        }
+    )
+
+    ref = visualize._get_reference_point(None, vocs, data, idx=0)
+    assert ref == {"x": 0.2, "y": 0.3}
+
+
+def test_get_reference_point_falls_back_to_idx_for_runtime_error(
+    vocs, data, monkeypatch
+):
+    def raise_runtime_error(*args, **kwargs):
+        raise RuntimeError("synthetic select_best failure")
+
+    monkeypatch.setattr(visualize, "select_best", raise_runtime_error)
+    ref = visualize._get_reference_point(None, vocs, data, idx=0)
+    assert ref == {"x": 0.0, "y": 0.0}
 
 
 def test_format_reference_point_title_wraps_long_text():
@@ -274,6 +310,22 @@ def test_format_reference_point_title_uses_fallback_names():
 def test_format_reference_point_title_empty_without_names():
     title = visualize._format_reference_point_title({}, [])
     assert title == "Reference point"
+
+
+def test_format_reference_point_title_handles_empty_wrap_result(monkeypatch):
+    reference_point = {"x": 0.25}
+
+    def empty_wrap(*args, **kwargs):
+        return []
+
+    monkeypatch.setattr(visualize.textwrap, "wrap", empty_wrap)
+    title = visualize._format_reference_point_title(
+        reference_point,
+        ["x"],
+        max_line_length=1,
+    )
+    assert title.startswith("Reference point:\n")
+    assert "x: 0.25" in title
 
 
 def test_verify_axes():

--- a/xopt/tests/generators/bayesian/test_visualize.py
+++ b/xopt/tests/generators/bayesian/test_visualize.py
@@ -221,6 +221,40 @@ def test_get_reference_point(vocs, data):
     assert isinstance(ref, dict)
 
 
+def test_format_reference_point_title_wraps_long_text():
+    reference_point = {
+        "SIOC:SYS1:ML00:AO551": 0.59,
+        "SIOC:SYS1:ML00:AO556": -1.2,
+        "SIOC:SYS1:ML00:AO501": 0.48,
+        "SIOC:SYS1:ML00:AO506": 0.42,
+    }
+    title = visualize._format_reference_point_title(
+        reference_point,
+        list(reference_point.keys()),
+        max_line_length=45,
+    )
+
+    assert title.startswith("Reference point:\n")
+    assert title.count("\n") > 1
+
+
+def test_format_reference_point_title_uses_fallback_names():
+    reference_point = {"x": 0.25, "y": 0.75}
+    title = visualize._format_reference_point_title(
+        reference_point,
+        [],
+        fallback_names=["x", "y"],
+    )
+    assert title.startswith("Reference point:\n")
+    assert "x: 0.25" in title
+    assert "y: 0.75" in title
+
+
+def test_format_reference_point_title_empty_without_names():
+    title = visualize._format_reference_point_title({}, [])
+    assert title == "Reference point"
+
+
 def test_verify_axes():
     with pytest.raises(ValueError):
         visualize._verify_axes("str", 5, 5)

--- a/xopt/tests/generators/bayesian/test_visualize.py
+++ b/xopt/tests/generators/bayesian/test_visualize.py
@@ -219,6 +219,27 @@ def test_validate_names(vocs):
 def test_get_reference_point(vocs, data):
     ref = visualize._get_reference_point(None, vocs, data)
     assert isinstance(ref, dict)
+    assert ref == {"x": 1.0, "y": 1.0}
+
+
+def test_get_reference_point_falls_back_to_idx_for_multi_objective():
+    vocs = VOCS(
+        variables={"x": [0, 1], "y": [0, 1]},
+        objectives={"obj1": "MAXIMIZE", "obj2": "MINIMIZE"},
+        constraints={},
+        observables=["obj1", "obj2"],
+    )
+    data = pd.DataFrame(
+        {
+            "x": [0.1, 0.9],
+            "y": [0.2, 0.8],
+            "obj1": [1.0, 0.0],
+            "obj2": [1.0, 0.0],
+        }
+    )
+
+    ref = visualize._get_reference_point(None, vocs, data, idx=0)
+    assert ref == {"x": 0.1, "y": 0.2}
 
 
 def test_format_reference_point_title_wraps_long_text():

--- a/xopt/tests/test_vocs.py
+++ b/xopt/tests/test_vocs.py
@@ -388,6 +388,30 @@ class TestVOCS(object):
             with pytest.raises(RuntimeError):
                 select_best(vocs, pd.DataFrame())
 
+    def test_select_best_unsupported_objectives(self):
+        test_data = pd.DataFrame(
+            {
+                "x1": [0.1, 0.2],
+                "x2": [0.1, 0.2],
+                "y1": [0.5, 0.6],
+                "y2": [0.7, 0.8],
+            }
+        )
+
+        # Explore-only objectives are not orderable for "best" point selection.
+        vocs = deepcopy(TEST_VOCS_BASE)
+        vocs.constraints = {}
+        vocs.objectives = {"y1": "EXPLORE"}
+        with pytest.raises(NotImplementedError, match="EXPLORE objective"):
+            select_best(vocs, test_data)
+
+        # Multi-objective problems are not supported by select_best.
+        vocs = deepcopy(TEST_VOCS_BASE)
+        vocs.constraints = {}
+        vocs.objectives = {"y1": "MAXIMIZE", "y2": "MINIMIZE"}
+        with pytest.raises(NotImplementedError, match="n_objectives is not 1"):
+            select_best(vocs, test_data)
+
     @pytest.mark.filterwarnings("ignore: All-NaN axis encountered")
     def test_cumulative_optimum(self):
         vocs = deepcopy(TEST_VOCS_BASE)

--- a/xopt/vocs.py
+++ b/xopt/vocs.py
@@ -642,9 +642,7 @@ def select_best(vocs: VOCS, data: pd.DataFrame, n: int = 1):
     obj_name = vocs.objective_names[0]
     obj = vocs.objectives[obj_name].__class__.__name__
     if obj == "ExploreObjective":
-        raise NotImplementedError(
-            "cannot select best point for EXPLORE objective"
-        )
+        raise NotImplementedError("cannot select best point for EXPLORE objective")
 
     if data.empty:
         raise RuntimeError("cannot select best point if dataframe is empty")

--- a/xopt/vocs.py
+++ b/xopt/vocs.py
@@ -618,6 +618,7 @@ def select_best(vocs: VOCS, data: pd.DataFrame, n: int = 1):
     """
     get the best value and point for a given data set based on vocs
     - does not work for multi-objective problems
+    - does not work for EXPLORE objectives
     - data that violates any constraints is ignored
 
     Parameters
@@ -638,6 +639,13 @@ def select_best(vocs: VOCS, data: pd.DataFrame, n: int = 1):
     if vocs.n_objectives != 1:
         raise NotImplementedError("cannot select best point when n_objectives is not 1")
 
+    obj_name = vocs.objective_names[0]
+    obj = vocs.objectives[obj_name].__class__.__name__
+    if obj == "ExploreObjective":
+        raise NotImplementedError(
+            "cannot select best point for EXPLORE objective"
+        )
+
     if data.empty:
         raise RuntimeError("cannot select best point if dataframe is empty")
 
@@ -648,8 +656,8 @@ def select_best(vocs: VOCS, data: pd.DataFrame, n: int = 1):
         )
 
     ascending_flag = {"MinimizeObjective": True, "MaximizeObjective": False}
-    obj = vocs.objectives[vocs.objective_names[0]].__class__.__name__
-    obj_name = vocs.objective_names[0]
+    if obj not in ascending_flag:
+        raise NotImplementedError(f"cannot select best point for objective type: {obj}")
 
     res = (
         data.loc[feasible_data["feasible"], :]


### PR DESCRIPTION
This pull request enhances the handling and display of reference points in the Bayesian model visualization utilities. It improves the logic for selecting a reference point, introduces a helper function to format reference point titles in a readable way, and adds comprehensive tests for these behaviors.

**Reference point selection improvements:**

* Updated `_get_reference_point` in `visualize.py` to select the best feasible point using `select_best` when possible, falling back to the sample at the given index for multi-objective or infeasible cases. The docstrings and parameter descriptions were updated accordingly. [[1]](diffhunk://#diff-9bdbe5b43cb39a9dde74d421358ab45457b996a0299adb5486dd72ce294bc00cL1090-R1099) [[2]](diffhunk://#diff-9bdbe5b43cb39a9dde74d421358ab45457b996a0299adb5486dd72ce294bc00cL1101-R1110) [[3]](diffhunk://#diff-9bdbe5b43cb39a9dde74d421358ab45457b996a0299adb5486dd72ce294bc00cL150-R157)

**Reference point display enhancements:**

* Added `_format_reference_point_title` to format and wrap reference point values for improved figure titles, and updated the main visualization function to use this helper for the figure title. [[1]](diffhunk://#diff-9bdbe5b43cb39a9dde74d421358ab45457b996a0299adb5486dd72ce294bc00cL212-R219) [[2]](diffhunk://#diff-9bdbe5b43cb39a9dde74d421358ab45457b996a0299adb5486dd72ce294bc00cL1110-R1169)
* Imported `textwrap` to support line wrapping in titles.

**Testing:**

* Added several tests in `test_visualize.py` to verify reference point selection logic and the formatting/wrapping of reference point titles, including edge cases such as multi-objective problems and missing names.

**Imports and dependencies:**

* Updated imports to include `select_best` and `FeasibilityError` for reference point selection logic.