### PR TITLE
Refactor BAX

### DIFF
--- a/docs/examples/single_objective_bayes_opt/bax_tutorial.ipynb
+++ b/docs/examples/single_objective_bayes_opt/bax_tutorial.ipynb
@@ -125,7 +125,9 @@
    "outputs": [],
    "source": [
     "# Prepare BAX algorithm and generator options\n",
-    "algorithm = GridOptimize(n_mesh_points=50)  # NOTE: default is to minimize\n",
+    "algorithm = GridOptimize(\n",
+    "    observable_names_ordered=[\"y1\"], n_mesh_points=50\n",
+    ")  # NOTE: default is to minimize\n",
     "\n",
     "# construct BAX generator\n",
     "generator = BaxGenerator(vocs=vocs, algorithm=algorithm)\n",
@@ -252,7 +254,12 @@
     "    # plot the function samples and their optima found by BAX\n",
     "    test_points = X.generator.algorithm_results[\"test_points\"]\n",
     "    posterior_samples = X.generator.algorithm_results[\"posterior_samples\"]\n",
-    "    execution_paths = X.generator.algorithm_results[\"execution_paths\"]\n",
+    "    sample_optima = torch.hstack(\n",
+    "        (\n",
+    "            X.generator.algorithm_results[\"best_inputs\"],\n",
+    "            X.generator.algorithm_results[\"best_objective\"],\n",
+    "        )\n",
+    "    )\n",
     "\n",
     "    label1 = \"Function Samples\"\n",
     "    label2 = \"Sample Optima\"\n",
@@ -261,7 +268,7 @@
     "            test_points, posterior_samples[i], c=\"C0\", alpha=0.3, label=label1\n",
     "        )\n",
     "        ax[1].scatter(\n",
-    "            *execution_paths[i], c=\"r\", marker=\"x\", s=80, label=label2, zorder=10\n",
+    "            *sample_optima[i], c=\"r\", marker=\"x\", s=80, label=label2, zorder=10\n",
     "        )\n",
     "        label1 = None\n",
     "        label2 = None\n",
@@ -363,7 +370,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.10"
+   "version": "3.12.4"
   }
  },
  "nbformat": 4,

--- a/xopt/generators/bayesian/bax/acquisition.py
+++ b/xopt/generators/bayesian/bax/acquisition.py
@@ -6,8 +6,6 @@ from botorch.models.model import Model, ModelList
 from botorch.utils.transforms import t_batch_mode_transform
 from torch import Tensor
 
-from xopt.generators.bayesian.bax.algorithms import Algorithm
-
 
 class ModelListExpectedInformationGain(MultiObjectiveAnalyticAcquisitionFunction):
     r"""Single-outcome expected information gain for independent

--- a/xopt/generators/bayesian/bax/acquisition.py
+++ b/xopt/generators/bayesian/bax/acquisition.py
@@ -11,30 +11,22 @@ from xopt.generators.bayesian.bax.algorithms import Algorithm
 
 class ModelListExpectedInformationGain(MultiObjectiveAnalyticAcquisitionFunction):
     r"""Single-outcome expected information gain for independent
-        multi-output (ModelListGP) models.
+    multi-output (ModelListGP) models.
 
-    Example:
-        >>> model1 = SingleTaskGP(train_X, train_Y1)
-        >>> model2 = SingleTaskGP(train_X, train_Y2)
-        >>> model = ModelList(model1, model2)
-        >>> EIG = ExpectedInformationGain(model, algo)
-        >>> eig = EIG(test_X)
-
-        Parameters
-        ----------
-            model: A fitted independent multi-output (ModelList) model.
+    Parameters
+    ----------
+        model: ModelList
+            A fitted independent multi-output (ModelList) model.
+        xs_exe: Tensor
+            The input execution paths.
+        ys_exe: Tensor
+            The output execution paths.
     """
 
-    def __init__(self, model: Model, algorithm: Algorithm, bounds: Tensor) -> None:
+    def __init__(self, model: Model, xs_exe: Tensor, ys_exe: Tensor) -> None:
         super().__init__(model=model)
-        self.algorithm = algorithm
-
-        # get sample-wise algorithm execution (BAX) results
-        (
-            self.xs_exe,
-            self.ys_exe,
-            self.algorithm_results,
-        ) = self.algorithm.get_execution_paths(self.model, bounds)
+        self.xs_exe = xs_exe
+        self.ys_exe = ys_exe
 
         # Need to call the model on some data before we can condition_on_observations
         self.model.posterior(self.xs_exe[:1, 0:1, 0:])

--- a/xopt/generators/bayesian/bax/acquisition.py
+++ b/xopt/generators/bayesian/bax/acquisition.py
@@ -2,7 +2,7 @@ import torch
 from botorch.acquisition.multi_objective.analytic import (
     MultiObjectiveAnalyticAcquisitionFunction,
 )
-from botorch.models.model import Model, ModelList
+from botorch.models.model import ModelList
 from botorch.utils.transforms import t_batch_mode_transform
 from torch import Tensor
 
@@ -21,7 +21,7 @@ class ModelListExpectedInformationGain(MultiObjectiveAnalyticAcquisitionFunction
             The output execution paths.
     """
 
-    def __init__(self, model: Model, xs_exe: Tensor, ys_exe: Tensor) -> None:
+    def __init__(self, model: ModelList, xs_exe: Tensor, ys_exe: Tensor) -> None:
         super().__init__(model=model)
         self.xs_exe = xs_exe
         self.ys_exe = ys_exe

--- a/xopt/generators/bayesian/bax/algorithms.py
+++ b/xopt/generators/bayesian/bax/algorithms.py
@@ -264,7 +264,7 @@ class GridOptimize(GridScanAlgorithm):
             solution_center=solution_center,
             solution_entropy=solution_entropy,
         )
-        # return algorithm result
+
         return algorithm_result
 
     def perform_virtual_measurement(

--- a/xopt/generators/bayesian/bax/algorithms.py
+++ b/xopt/generators/bayesian/bax/algorithms.py
@@ -10,19 +10,44 @@ from xopt.pydantic import XoptBaseModel
 
 
 class AlgorithmResult(BaseModel):
-    model_config = ConfigDict(arbitrary_types_allowed=True, extra="allow")
-    input_execution_paths: Tensor
-    output_execution_paths: Tensor
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+    input_execution_paths: Tensor = Field(
+        description="The algorithm execution paths in input space."
+    )
+    output_execution_paths: Tensor = Field(
+        description="The algorithm execution paths in output space."
+    )
 
 
 class OptimizationAlgorithmResult(AlgorithmResult):
-    best_inputs: Tensor
-    best_objective: Tensor
+    best_inputs: Tensor = Field(
+        description="The optimal inputs from the sample-wise optimization of the virtual objective."
+    )
+    best_objective: Tensor = Field(
+        description="The optimal objective values from the sample-wise optimization of the virtual objective."
+    )
+    solution_center: Tensor = Field(
+        None,
+        description="The mean of the distribution of optimal inputs from the sample-wise optimization of the virtual objective.",
+    )
+    solution_entropy: float = Field(
+        None,
+        description="The entropy of the distribution of optimal inputs from the sample-wise optimization of the virtual objective.",
+    )
+
+
+class GridOptimizeResult(OptimizationAlgorithmResult):
+    test_points: Tensor = Field(description="The inputs evaluated by the grid scan.")
+    posterior_samples: Tensor = Field(
+        description="The objective values evaluated at the grid inputs by the grid scan."
+    )
 
 
 class VirtualMeasurementResult(BaseModel):
-    model_config = ConfigDict(arbitrary_types_allowed=True, extra="allow")
-    objective: Tensor
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+    objective: Tensor = Field(
+        description="The objective value as evaluated by the virtual measurement."
+    )
 
 
 class Algorithm(XoptBaseModel, ABC):
@@ -38,9 +63,9 @@ class Algorithm(XoptBaseModel, ABC):
 
     Methods
     -------
-    get_execution_paths(self, model: Model, bounds: Tensor) -> Tuple[Tensor, Tensor, Dict]
-        Get execution paths for the algorithm.
-    perform_virtual_measurement(self, model: Model, x: Tensor, bounds: Tensor, n_samples: int, tkwargs: dict = None) -> Tensor
+    execute(self, model: Model, bounds: Tensor) -> AlgorithmResult
+        Draw samples from the model, execute the algorithm on the samples, and return algorithm results.
+    perform_virtual_measurement(self, model: Model, x: Tensor, bounds: Tensor, n_samples: int, tkwargs: dict = None) -> VirtualMeasurementResult
         Perform the virtual measurement and calculate objective values at the given inputs.
     """
 
@@ -57,7 +82,7 @@ class Algorithm(XoptBaseModel, ABC):
     @abstractmethod
     def execute(self, model: Model, bounds: Tensor) -> AlgorithmResult:
         """
-        Execute the algorithm on samples and return results.
+        Draw samples from the model, execute the algorithm on the samples, and return results.
 
         Parameters
         ----------
@@ -71,7 +96,7 @@ class Algorithm(XoptBaseModel, ABC):
         AlgorithmResult
             The algorithm result with input and output execution paths.
         """
-        pass
+        raise NotImplementedError
 
     @abstractmethod
     def perform_virtual_measurement(
@@ -103,7 +128,7 @@ class Algorithm(XoptBaseModel, ABC):
         VirtualMeasurementResult
             The virtual measurement result with computed objective values.
         """
-        pass  # pragma: no cover
+        raise NotImplementedError  # pragma: no cover
 
 
 class GridScanAlgorithm(Algorithm, ABC):
@@ -182,12 +207,11 @@ class GridOptimize(GridScanAlgorithm):
     """
 
     observable_names_ordered: List[str] = Field(
-        default=["y1"],
         description="names of observable/objective models used in this algorithm",
     )
     minimize: bool = True
 
-    def execute(self, model: Model, bounds: Tensor) -> AlgorithmResult:
+    def execute(self, model: Model, bounds: Tensor) -> GridOptimizeResult:
         """
         Execute the algorithm on samples and collect the results of the optimization.
 
@@ -200,7 +224,7 @@ class GridOptimize(GridScanAlgorithm):
 
         Returns
         -------
-        OptimizationAlgorithmResult
+        GridOptimizeResult
             Contains best_inputs, best_objective, input_execution_paths, output_execution_paths, and additional results.
         """
         # build evaluation mesh
@@ -227,15 +251,14 @@ class GridOptimize(GridScanAlgorithm):
 
         # get the solution_center and solution_entropy for Turbo
         # note: the entropy calc here drops a constant scaling factor
-        solution_center = x_opt.mean(dim=0).numpy()
+        solution_center = x_opt.mean(dim=0)
         solution_entropy = float(torch.log(x_opt.std(dim=0) ** 2).sum())
 
-        algorithm_result = OptimizationAlgorithmResult(
+        algorithm_result = GridOptimizeResult(
             best_inputs=x_opt,
             best_objective=y_opt,
             input_execution_paths=x_opt.unsqueeze(-2),
             output_execution_paths=y_opt.unsqueeze(-2),
-            execution_paths=torch.hstack((x_opt, y_opt)),
             test_points=test_points,
             posterior_samples=posterior_samples,
             solution_center=solution_center,

--- a/xopt/generators/bayesian/bax/algorithms.py
+++ b/xopt/generators/bayesian/bax/algorithms.py
@@ -3,10 +3,28 @@ from typing import ClassVar, Dict, List, Tuple
 
 import torch
 from botorch.models.model import Model, ModelList
-from pydantic import Field, PositiveInt, computed_field
+from pydantic import BaseModel, ConfigDict, Field, PositiveInt, computed_field
 from torch import Tensor
 
 from xopt.pydantic import XoptBaseModel
+
+from pydantic import BaseModel
+
+
+class AlgorithmResult(BaseModel):
+    model_config = ConfigDict(arbitrary_types_allowed=True, extra="allow")
+    input_execution_paths: Tensor
+    output_execution_paths: Tensor
+
+
+class OptimizationAlgorithmResult(AlgorithmResult):
+    best_inputs: Tensor
+    best_objective: Tensor
+
+
+class VirtualMeasurementResult(BaseModel):
+    model_config = ConfigDict(arbitrary_types_allowed=True, extra="allow")
+    objective: Tensor
 
 
 class Algorithm(XoptBaseModel, ABC):
@@ -24,8 +42,8 @@ class Algorithm(XoptBaseModel, ABC):
     -------
     get_execution_paths(self, model: Model, bounds: Tensor) -> Tuple[Tensor, Tensor, Dict]
         Get execution paths for the algorithm.
-    evaluate_virtual_objective(self, model: Model, x: Tensor, bounds: Tensor, n_samples: int, tkwargs: dict = None) -> Tensor
-        Evaluate the virtual objective at the given inputs.
+    perform_virtual_measurement(self, model: Model, x: Tensor, bounds: Tensor, n_samples: int, tkwargs: dict = None) -> Tensor
+        Perform the virtual measurement and calculate objective values at the given inputs.
     """
 
     name: ClassVar[str] = "base_algorithm"
@@ -39,11 +57,9 @@ class Algorithm(XoptBaseModel, ABC):
         return f"{self.__class__.__module__}.{self.__class__.__name__}"
 
     @abstractmethod
-    def get_execution_paths(
-        self, model: Model, bounds: Tensor
-    ) -> Tuple[Tensor, Tensor, Dict]:
+    def execute(self, model: Model, bounds: Tensor) -> AlgorithmResult:
         """
-        Get execution paths for the algorithm.
+        Execute the algorithm on samples and return results.
 
         Parameters
         ----------
@@ -54,20 +70,20 @@ class Algorithm(XoptBaseModel, ABC):
 
         Returns
         -------
-        Tuple[Tensor, Tensor, Dict]
-            The execution paths, their corresponding values, and additional results.
+        AlgorithmResult
+            The algorithm result with input and output execution paths.
         """
         pass
 
     @abstractmethod
-    def evaluate_virtual_objective(
+    def perform_virtual_measurement(
         self,
         model: Model,
         x: Tensor,
         bounds: Tensor,
         n_samples: int,
         tkwargs: dict = None,
-    ) -> Tensor:
+    ) -> VirtualMeasurementResult:
         """
         Evaluate the virtual objective at the given inputs.
 
@@ -86,8 +102,8 @@ class Algorithm(XoptBaseModel, ABC):
 
         Returns
         -------
-        Tensor
-            The evaluated virtual objective values.
+        VirtualMeasurementResult
+            The virtual measurement result with computed objective values.
         """
         pass  # pragma: no cover
 
@@ -163,8 +179,8 @@ class GridOptimize(GridScanAlgorithm):
     -------
     get_execution_paths(self, model: Model, bounds: Tensor) -> Tuple[Tensor, Tensor, Dict]
         Get execution paths that minimize the objective function.
-    evaluate_virtual_objective(self, model: Model, x: Tensor, bounds: Tensor, n_samples: int, tkwargs: dict = None) -> Tensor
-        Evaluate the virtual objective (samples).
+    perform_virtual_measurement(self, model: Model, x: Tensor, bounds: Tensor, n_samples: int, tkwargs: dict = None) -> VirtualMeasurementResult
+        Evaluate the virtual measurement and calculate objective values (samples).
     """
 
     observable_names_ordered: List[str] = Field(
@@ -173,11 +189,9 @@ class GridOptimize(GridScanAlgorithm):
     )
     minimize: bool = True
 
-    def get_execution_paths(
-        self, model: Model, bounds: Tensor
-    ) -> Tuple[Tensor, Tensor, Dict]:
+    def execute(self, model: Model, bounds: Tensor) -> AlgorithmResult:
         """
-        Get execution paths that minimize the objective function.
+        Execute the algorithm on samples and collect the results of the optimization.
 
         Parameters
         ----------
@@ -188,8 +202,8 @@ class GridOptimize(GridScanAlgorithm):
 
         Returns
         -------
-        Tuple[Tensor, Tensor, Dict]
-            The execution paths, their corresponding values, and additional results.
+        OptimizationAlgorithmResult
+            Contains best_inputs, best_objective, input_execution_paths, output_execution_paths, and additional results.
         """
         # build evaluation mesh
         test_points = self.create_mesh(bounds)
@@ -199,10 +213,11 @@ class GridOptimize(GridScanAlgorithm):
             test_points = test_points.to(model.train_targets)
 
         # get samples of the model posterior at mesh points
-        posterior_samples = self.evaluate_virtual_objective(
+        result = self.perform_virtual_measurement(
             model, test_points, bounds, self.n_samples
         )
 
+        posterior_samples = result.objective
         # get points that minimize each sample (execution paths)
         if self.minimize:
             y_opt, opt_idx = torch.min(posterior_samples, dim=-2)
@@ -217,28 +232,30 @@ class GridOptimize(GridScanAlgorithm):
         solution_center = x_opt.mean(dim=0).numpy()
         solution_entropy = float(torch.log(x_opt.std(dim=0) ** 2).sum())
 
-        # collect secondary results in a dict
-        results_dict = {
-            "test_points": test_points,
-            "posterior_samples": posterior_samples,
-            "execution_paths": torch.hstack((x_opt, y_opt)),
-            "solution_center": solution_center,
-            "solution_entropy": solution_entropy,
-        }
+        algorithm_result = OptimizationAlgorithmResult(
+            best_inputs=x_opt,
+            best_objective=y_opt,
+            input_execution_paths=x_opt.unsqueeze(-2),
+            output_execution_paths=y_opt.unsqueeze(-2),
+            execution_paths=torch.hstack((x_opt, y_opt)),
+            test_points=test_points,
+            posterior_samples=posterior_samples,
+            solution_center=solution_center,
+            solution_entropy=solution_entropy,
+        )
+        # return algorithm result
+        return algorithm_result
 
-        # return execution paths
-        return x_opt.unsqueeze(-2), y_opt.unsqueeze(-2), results_dict
-
-    def evaluate_virtual_objective(
+    def perform_virtual_measurement(
         self,
         model: Model,
         x: Tensor,
         bounds: Tensor,
         n_samples: int,
         tkwargs: dict = None,
-    ) -> Tensor:
+    ) -> VirtualMeasurementResult:
         """
-        Evaluate the virtual objective (samples).
+        Perform the virtual measurement (samples).
 
         Parameters
         ----------
@@ -255,15 +272,14 @@ class GridOptimize(GridScanAlgorithm):
 
         Returns
         -------
-        Tensor
-            The evaluated virtual objective values.
+        VirtualMeasurementResult
+            The virtual measurement result with calculated virtual objective values.
         """
-        # get samples of the model posterior at inputs given by x
         with torch.no_grad():
             post = model.posterior(x)
             objective_values = post.rsample(torch.Size([n_samples]))
 
-        return objective_values
+        return VirtualMeasurementResult(objective=objective_values)
 
 
 class CurvatureGridOptimize(GridOptimize):
@@ -277,20 +293,20 @@ class CurvatureGridOptimize(GridOptimize):
 
     Methods
     -------
-    evaluate_virtual_objective(self, model: Model, x: Tensor, bounds: Tensor, n_samples: int, tkwargs: dict = None) -> Tensor
-        Evaluate the virtual objective (samples) with curvature.
+    perform_virtual_measurement(self, model: Model, x: Tensor, bounds: Tensor, n_samples: int, tkwargs: dict = None) -> VirtualMeasurementResult
+        Perform the virtual measurement (samples) with curvature.
     """
 
     use_mean: bool = False
 
-    def evaluate_virtual_objective(
+    def perform_virtual_measurement(
         self,
         model: Model,
         x: Tensor,
         bounds: Tensor,
         n_samples: int,
         tkwargs: dict = None,
-    ) -> Tensor:
+    ) -> VirtualMeasurementResult:
         """
         Evaluate the virtual objective (samples) with curvature.
 
@@ -309,8 +325,8 @@ class CurvatureGridOptimize(GridOptimize):
 
         Returns
         -------
-        Tensor
-            The evaluated virtual objective values with curvature.
+        VirtualMeasurementResult
+            The virtual measurement result with calculated virtual objective values with curvature.
         """
         # get samples of the model posterior at inputs given by x
         with torch.no_grad():
@@ -330,4 +346,4 @@ class CurvatureGridOptimize(GridOptimize):
         objective_values[:, 0] = 0
         objective_values[:, -1] = 0
 
-        return objective_values
+        return VirtualMeasurementResult(objective=objective_values)

--- a/xopt/generators/bayesian/bax/algorithms.py
+++ b/xopt/generators/bayesian/bax/algorithms.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import ClassVar, Dict, List, Tuple
+from typing import ClassVar, List
 
 import torch
 from botorch.models.model import Model, ModelList
@@ -7,8 +7,6 @@ from pydantic import BaseModel, ConfigDict, Field, PositiveInt, computed_field
 from torch import Tensor
 
 from xopt.pydantic import XoptBaseModel
-
-from pydantic import BaseModel
 
 
 class AlgorithmResult(BaseModel):

--- a/xopt/generators/bayesian/bax/visualize.py
+++ b/xopt/generators/bayesian/bax/visualize.py
@@ -102,9 +102,10 @@ def visualize_virtual_objective(
     # get virtual objective (sample) values
     bounds = generator._get_optimization_bounds()
     kwargs = kwargs if kwargs else {}
-    objective_values = generator.algorithm.evaluate_virtual_objective(
+    measurement_result = generator.algorithm.perform_virtual_measurement(
         bax_model, x, bounds, tkwargs=tkwargs, n_samples=n_samples, **kwargs
     )
+    objective_values = measurement_result.objective
 
     # get sample stats
     objective_med = objective_values.nanmedian(dim=0)[0].flatten()

--- a/xopt/generators/bayesian/bax_generator.py
+++ b/xopt/generators/bayesian/bax_generator.py
@@ -148,10 +148,17 @@ class BaxGenerator(BayesianGenerator):
         if isinstance(bax_model, SingleTaskGP):
             bax_model = ModelListGP(bax_model)
 
-        eig = ModelListExpectedInformationGain(
-            bax_model, self.algorithm, self._get_optimization_bounds()
-        )
-        self.algorithm_results = eig.algorithm_results
+        # get sample-wise algorithm execution (BAX) results
+        algorithm_results = self.algorithm.execute(
+            bax_model, self._get_optimization_bounds()
+        ).model_dump()
+
+        self.algorithm_results = algorithm_results
+        xs_exe = algorithm_results["input_execution_paths"]
+        ys_exe = algorithm_results["output_execution_paths"]
+
+        eig = ModelListExpectedInformationGain(bax_model, xs_exe, ys_exe)
+
         if self.algorithm_results_file is not None:
             results = deepcopy(self.algorithm_results)
 

--- a/xopt/tests/generators/bayesian/test_bax.py
+++ b/xopt/tests/generators/bayesian/test_bax.py
@@ -97,13 +97,15 @@ class TestBaxGenerator:
                 return super().execute(model, bounds)
 
         alg = DummyAlgorithm()
-        alg.execute(None, None)
+
+        with pytest.raises(NotImplementedError):
+            alg.execute(None, None)
 
     def test_grid_minimize(self):
         # test grid scan minimize
         for ndim in [1, 3]:
             bounds = torch.stack([torch.zeros(ndim), torch.ones(ndim)])
-            alg = GridOptimize()
+            alg = GridOptimize(observable_names_ordered=["y1"])
 
             # create a ModelList with a single output
             train_X = torch.rand(10, ndim, dtype=torch.float64)
@@ -161,7 +163,7 @@ class TestBaxGenerator:
                 input_transform=Normalize(ndim),
                 outcome_transform=Standardize(1),
             )
-            alg = GridOptimize(minimize=False)
+            alg = GridOptimize(observable_names_ordered=["y1"], minimize=False)
             algorithm_result = alg.execute(model, bounds)
             x_exe = algorithm_result.input_execution_paths
             y_exe = algorithm_result.output_execution_paths
@@ -175,7 +177,7 @@ class TestBaxGenerator:
     def test_acquisition_func(self):
         torch.manual_seed(1)
 
-        alg = GridOptimize()
+        alg = GridOptimize(observable_names_ordered=["y1"])
 
         # test w/o constraints
         test_vocs = deepcopy(TEST_VOCS_BASE)
@@ -235,7 +237,7 @@ class TestBaxGenerator:
         assert torch.allclose(acqf_vals, test_acqf_vals, atol=1e-4)
 
     def test_generate(self):
-        alg = GridOptimize()
+        alg = GridOptimize(observable_names_ordered=["y1"])
 
         # test w/o constraints
         test_vocs = deepcopy(TEST_VOCS_BASE)
@@ -268,7 +270,7 @@ class TestBaxGenerator:
         assert len(candidate) == 1
 
     def test_cuda(self):
-        alg = GridOptimize()
+        alg = GridOptimize(observable_names_ordered=["y1"])
         test_vocs = deepcopy(TEST_VOCS_BASE)
         test_vocs.objectives = {}
         test_vocs.observables = ["y1"]
@@ -286,7 +288,7 @@ class TestBaxGenerator:
 
     def test_in_xopt(self):
         evaluator = Evaluator(function=xtest_callable)
-        alg = GridOptimize()
+        alg = GridOptimize(observable_names_ordered=["y1"])
 
         test_vocs = deepcopy(TEST_VOCS_BASE)
         test_vocs.objectives = {}
@@ -305,7 +307,7 @@ class TestBaxGenerator:
 
     def test_file_saving(self):
         evaluator = Evaluator(function=xtest_callable)
-        alg = GridOptimize()
+        alg = GridOptimize(observable_names_ordered=["y1"])
 
         test_vocs = deepcopy(TEST_VOCS_BASE)
         test_vocs.objectives = {}
@@ -324,9 +326,12 @@ class TestBaxGenerator:
         with open("test_2.pkl", "rb") as handle:
             result = pickle.load(handle)
 
+        assert isinstance(result["input_execution_paths"], torch.Tensor)
+        assert isinstance(result["output_execution_paths"], torch.Tensor)
+        assert isinstance(result["best_inputs"], torch.Tensor)
+        assert isinstance(result["best_objective"], torch.Tensor)
         assert isinstance(result["test_points"], torch.Tensor)
         assert isinstance(result["posterior_samples"], torch.Tensor)
-        assert isinstance(result["execution_paths"], torch.Tensor)
 
         import os
 
@@ -335,7 +340,7 @@ class TestBaxGenerator:
 
     def test_vocs_validation(self):
         test_vocs = deepcopy(TEST_VOCS_BASE)
-        alg = GridOptimize()
+        alg = GridOptimize(observable_names_ordered=["y1"])
 
         with pytest.raises(VOCSError):
             BaxGenerator(vocs=test_vocs, algorithm=alg)
@@ -345,7 +350,7 @@ class TestBaxGenerator:
         test_vocs.objectives = {"y1": "MINIMIZE"}
         test_vocs.observables = []
         test_vocs.constraints = {}
-        alg = GridOptimize()
+        alg = GridOptimize(observable_names_ordered=["y1"])
 
         with pytest.raises(
             VOCSError, match="only supports problems with no objectives"
@@ -388,7 +393,9 @@ class TestBaxGenerator:
             input_transform=Normalize(ndim),
             outcome_transform=Standardize(1),
         )
-        alg = CurvatureGridOptimize(n_samples=3, use_mean=False)
+        alg = CurvatureGridOptimize(
+            observable_names_ordered=["y1"], n_samples=3, use_mean=False
+        )
         mesh = alg.create_mesh(bounds)
         measurement_result = alg.perform_virtual_measurement(
             model, mesh, bounds, n_samples=3
@@ -412,7 +419,9 @@ class TestBaxGenerator:
             input_transform=Normalize(ndim),
             outcome_transform=Standardize(1),
         )
-        alg = CurvatureGridOptimize(n_samples=2, use_mean=True)
+        alg = CurvatureGridOptimize(
+            observable_names_ordered=["y1"], n_samples=2, use_mean=True
+        )
         mesh = alg.create_mesh(bounds)
         measurement_result = alg.perform_virtual_measurement(
             model, mesh, bounds, n_samples=2
@@ -429,7 +438,7 @@ class TestBaxGenerator:
         test_vocs = deepcopy(TEST_VOCS_BASE)
         test_vocs.objectives = {}
         test_vocs.observables = ["y1"]
-        alg = GridOptimize()
+        alg = GridOptimize(observable_names_ordered=["y1"])
         gen = BaxGenerator(vocs=test_vocs, algorithm=alg, n_monte_carlo_samples=10)
         gen.numerical_optimizer.n_restarts = 1
 
@@ -444,7 +453,7 @@ class TestBaxGenerator:
 
     def test_visualization(self):
         evaluator = Evaluator(function=xtest_callable)
-        alg = GridOptimize()
+        alg = GridOptimize(observable_names_ordered=["y1"])
 
         test_vocs = deepcopy(TEST_VOCS_BASE)
         test_vocs.objectives = {}

--- a/xopt/tests/generators/bayesian/test_bax.py
+++ b/xopt/tests/generators/bayesian/test_bax.py
@@ -86,18 +86,18 @@ class TestBaxGenerator:
         with pytest.raises(ValueError, match=r"bounds must have the shape \[2, ndim\]"):
             alg.create_mesh(invalid_bounds)
 
-    def test_algorithm_get_execution_paths_not_implemented(self):
+    def test_algorithm_execute_not_implemented(self):
         class DummyAlgorithm(Algorithm):
-            def evaluate_virtual_objective(
+            def perform_virtual_measurement(
                 self, model, x, bounds, n_samples, tkwargs=None
             ):
                 return torch.zeros(1)
 
-            def get_execution_paths(self, model, bounds):
-                return super().get_execution_paths(model, bounds)
+            def execute(self, model, bounds):
+                return super().execute(model, bounds)
 
         alg = DummyAlgorithm()
-        alg.get_execution_paths(None, None)
+        alg.execute(None, None)
 
     def test_grid_minimize(self):
         # test grid scan minimize
@@ -118,7 +118,9 @@ class TestBaxGenerator:
                 )
             )
 
-            x_exe, y_exe, results = alg.get_execution_paths(model, bounds)
+            algorithm_result = alg.execute(model, bounds)
+            x_exe = algorithm_result.input_execution_paths
+            y_exe = algorithm_result.output_execution_paths
 
             # execution paths should be able to be transformed and used in
             # `condition_on_observations` method
@@ -160,9 +162,12 @@ class TestBaxGenerator:
                 outcome_transform=Standardize(1),
             )
             alg = GridOptimize(minimize=False)
-            x_exe, y_exe, results = alg.get_execution_paths(model, bounds)
+            algorithm_result = alg.execute(model, bounds)
+            x_exe = algorithm_result.input_execution_paths
+            y_exe = algorithm_result.output_execution_paths
+
             # Should select the maximum value from posterior_samples
-            posterior_samples = results["posterior_samples"]
+            posterior_samples = algorithm_result.posterior_samples
             y_max, idx_max = torch.max(posterior_samples, dim=-2)
             assert torch.allclose(y_exe.squeeze(-2), y_max)
             assert x_exe.shape[0] == alg.n_samples
@@ -385,13 +390,16 @@ class TestBaxGenerator:
         )
         alg = CurvatureGridOptimize(n_samples=3, use_mean=False)
         mesh = alg.create_mesh(bounds)
-        result = alg.evaluate_virtual_objective(model, mesh, bounds, n_samples=3)
+        measurement_result = alg.perform_virtual_measurement(
+            model, mesh, bounds, n_samples=3
+        )
+        objective = measurement_result.objective
         # Should have shape [n_samples, mesh_points, 1]
-        assert result.shape[0] == 3
-        assert result.shape[1] == mesh.shape[0]
+        assert objective.shape[0] == 3
+        assert objective.shape[1] == mesh.shape[0]
         # Edge values should be zero
-        assert torch.all(result[:, 0] == 0)
-        assert torch.all(result[:, -1] == 0)
+        assert torch.all(objective[:, 0] == 0)
+        assert torch.all(objective[:, -1] == 0)
 
     def test_curvature_grid_optimize_use_mean(self):
         ndim = 1
@@ -406,13 +414,16 @@ class TestBaxGenerator:
         )
         alg = CurvatureGridOptimize(n_samples=2, use_mean=True)
         mesh = alg.create_mesh(bounds)
-        result = alg.evaluate_virtual_objective(model, mesh, bounds, n_samples=2)
+        measurement_result = alg.perform_virtual_measurement(
+            model, mesh, bounds, n_samples=2
+        )
+        objective = measurement_result.objective
         # Should have shape [1, mesh_points, 1] since use_mean=True
-        assert result.shape[0] == 1
-        assert result.shape[1] == mesh.shape[0]
+        assert objective.shape[0] == 1
+        assert objective.shape[1] == mesh.shape[0]
         # Edge values should be zero
-        assert torch.all(result[:, 0] == 0)
-        assert torch.all(result[:, -1] == 0)
+        assert torch.all(objective[:, 0] == 0)
+        assert torch.all(objective[:, -1] == 0)
 
     def test_bax_serialization(self):
         test_vocs = deepcopy(TEST_VOCS_BASE)

--- a/xopt/tests/generators/bayesian/test_bax_visualize.py
+++ b/xopt/tests/generators/bayesian/test_bax_visualize.py
@@ -16,7 +16,7 @@ class TestVisualizeBax:
     @pytest.fixture
     def bax_generator(self):
         evaluator = Evaluator(function=xtest_callable)
-        alg = GridOptimize()
+        alg = GridOptimize(observable_names_ordered=["y1"])
 
         test_vocs = deepcopy(TEST_VOCS_BASE)
         test_vocs.objectives = {}
@@ -64,7 +64,7 @@ class TestVisualizeBax:
     def test_unsupported_dim_x(self, bax_generator):
         # Add a third variable to VOCS for this test
         evaluator = Evaluator(function=xtest_callable)
-        alg = GridOptimize()
+        alg = GridOptimize(observable_names_ordered=["y1"])
 
         test_vocs = deepcopy(TEST_VOCS_BASE)
         test_vocs.variable_names.append("x3")

--- a/xopt/tests/generators/bayesian/test_turbo.py
+++ b/xopt/tests/generators/bayesian/test_turbo.py
@@ -518,7 +518,9 @@ class TestTurbo(TestCase):
             return {"y1": np.sin(input_dict["x"])}
 
         # Prepare BAX algorithm and generator options
-        algorithm = GridOptimize(n_mesh_points=10)  # NOTE: default is to minimize
+        algorithm = GridOptimize(
+            observable_names_ordered=["y1"], n_mesh_points=10
+        )  # NOTE: default is to minimize
 
         # construct BAX generator
         generator = BaxGenerator(

--- a/xopt/tests/test_generator.py
+++ b/xopt/tests/test_generator.py
@@ -101,7 +101,9 @@ class TestGenerator:
             test_vocs = deepcopy(TEST_VOCS_BASE)
             test_vocs.objectives = {}
             test_vocs.observables = ["y1"]
-            gen_config["algorithm"] = GridOptimize().model_dump()
+            gen_config["algorithm"] = GridOptimize(
+                observable_names_ordered=["y1"]
+            ).model_dump()
             json.dumps(gen_config)
 
             gen_class(vocs=test_vocs, **gen_config)


### PR DESCRIPTION
Refactors BAX so that:

-BaxGenerator runs the algorithm and stores algorithm results directly (instead of passing the algorithm to the acquisition function)
-Acquisition function only requires model and execution paths for initialization
-Virtual (objective) measurement result and algorithm execution results (execution paths) are returned as pydantic objects with standardized fields (for bookkeeping/visualization functions)
-Changes Algorithm.get_execution_paths() to Algorithm.execute() because it returns a more general AlgorithmResult object
-Changes Algorithm.evaluate_virtual_objective() to Algorithm.perform_virtual_measurement() because it returns a more general VirtualMeasurementResult object

