### PR TITLE
Initial Data Loading in `xopt-run`

### DIFF
--- a/docs/examples/basic/xopt_cli.md
+++ b/docs/examples/basic/xopt_cli.md
@@ -12,7 +12,7 @@ Once Xopt is installed from conda/pip, the tool will be available in your system
 
 ```
 xopt-run [-h] [--executor {map,thread_pool,process_pool}] [--max_workers MAX_WORKERS]
-         [--python_path PYTHON_PATH] [--override OVERRIDE] [-v] config
+         [--python_path PYTHON_PATH] [--override OVERRIDE] [--initial_data INITIAL_DATA] [-v] config
 ```
 
 The available arguments are the following.
@@ -23,6 +23,7 @@ The available arguments are the following.
 - `--max_workers`: Override the number of workers in Xopt and launch this number of threads/processes if using a parallel executor.
 - `--python_path`: Add this directory to your python path. By default, the current working directory. May include environment variables and the character `~` to represent the user's home directory. Note: you can pass these values into the tool without shell expansion by surrounding them by single quotes. May have more than one of this flag.
 - `--override`: Override a value from the YAML config file. May have more than one of this flag. More details below.
+- `--initial_data`: CSV file with initial data to seed the generator before running.
 - `-v`, `--verbose`: Display verbose output (`logging.DEBUG` level messages) from Xopt
 
 ## Overriding Settings in Config File
@@ -42,6 +43,14 @@ Xopt will automatically import the package and then use the specified function f
 
 The argument `--python_path <path>` is used to add the directory containing your python file with the evaluation function to your python path.
 By default, the current working directory is included in your python path.
+
+## Seeding Optimization with Existing Data
+
+It is sometimes useful to load already evaluated data into the `Xopt` optimizer before running.
+For example, to pick up an optimization from the results of a previous run (for generators without a checkpointing feature) or to "seed" the optimizer with related results or lower fidelity simulation outputs.
+The arugment `--initial_data` is used to specify a path to a CSV file containing the data to seed the generator with.
+The CSV file will be loaded and passed to `Xopt.add_data` before running the optimizer.
+As such, the CSV file is expected to have a header row and columns that have the same names as the keys in the VOCS of the problem being optimized.
 
 ## Example Usage
 ### Calling an Evaluation Function from a Python File

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,7 +20,8 @@ Currenty **Xopt** provides:
 
 - Optimization algorithms:
   - Genetic algorithms
-    - [`cnsga`](examples\ga\cnsga_tnk.ipynb) Continuous NSGA-II with constraints
+    - [`NSGA-II`](examples\ga\nsga2\index.md) Implementation of NSGA-II: Non-dominated sorting genetic algorithm
+    - [`cnsga`](examples\ga\cnsga_tnk.ipynb) NSGA-II adapted for use with "continuous generators"
   - Bayesian optimization (BO) algorithms:
     - [`upper_confidence_bound`](examples\single_objective_bayes_opt\upper_confidence_bound.ipynb) BO using Upper Confidence Bound acquisition function
       (w/ or w/o constraints, serial or parallel)

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,33 +20,33 @@ Currenty **Xopt** provides:
 
 - Optimization algorithms:
   - Genetic algorithms
-    - [`NSGA-II`](examples\ga\nsga2\index.md) Implementation of NSGA-II: Non-dominated sorting genetic algorithm
-    - [`cnsga`](examples\ga\cnsga_tnk.ipynb) NSGA-II adapted for use with "continuous generators"
+    - [`NSGA-II`](examples/ga/nsga2/index.md) Implementation of NSGA-II: Non-dominated sorting genetic algorithm
+    - [`cnsga`](examples/ga/cnsga_tnk.ipynb) NSGA-II adapted for use with "continuous generators"
   - Bayesian optimization (BO) algorithms:
-    - [`upper_confidence_bound`](examples\single_objective_bayes_opt\upper_confidence_bound.ipynb) BO using Upper Confidence Bound acquisition function
+    - [`upper_confidence_bound`](examples/single_objective_bayes_opt/upper_confidence_bound.ipynb) BO using Upper Confidence Bound acquisition function
       (w/ or w/o constraints, serial or parallel)
-    - [`expected_improvement`](examples\single_objective_bayes_opt\bo_tutorial.ipynb) BO using Expected Improvement acquisition function
+    - [`expected_improvement`](examples/single_objective_bayes_opt/bo_tutorial.ipynb) BO using Expected Improvement acquisition function
       (w/ or w/o constraints, serial or parallel)
-    - [`mobo`](examples\multi_objective_bayes_opt\mobo.ipynb) Multi-objective BO (w/ or w/o constraints, serial or parallel)
-    - [`bayesian_exploration`](examples\bayes_exp\bayesian_exploration.ipynb) Autonomous function characterization using Bayesian
+    - [`mobo`](examples/multi_objective_bayes_opt/mobo.ipynb) Multi-objective BO (w/ or w/o constraints, serial or parallel)
+    - [`bayesian_exploration`](examples/bayes_exp/bayesian_exploration.ipynb) Autonomous function characterization using Bayesian
       Exploration
-    - [`mggpo`](examples\multi_objective_bayes_opt\mggpo.ipynb) Parallelized hybrid Multi-Generation Multi-Objective Bayesian
+    - [`mggpo`](examples/multi_objective_bayes_opt/mggpo.ipynb) Parallelized hybrid Multi-Generation Multi-Objective Bayesian
       optimization
-    - [`multi_fidelity`](examples\single_objective_bayes_opt\multi_fidelity_simple.ipynb) Multi-fidelity single or multi objective optimization
-    - [`BAX`](examples\single_objective_bayes_opt\bax_tutorial.ipynb) Bayesian algorithm execution using virtual measurements
+    - [`multi_fidelity`](examples/single_objective_bayes_opt/multi_fidelity_simple.ipynb) Multi-fidelity single or multi objective optimization
+    - [`BAX`](examples/single_objective_bayes_opt/bax_tutorial.ipynb) Bayesian algorithm execution using virtual measurements
     - BO customization:
-      - [Trust region BO](examples\trust_region_bo\turbo_basics.ipynb)
-      - [Heteroskedastic noise specification](examples\single_objective_bayes_opt\heteroskedastic_noise_tutorial.ipynb)
+      - [Trust region BO](examples/trust_region_bo/turbo_basics.ipynb)
+      - [Heteroskedastic noise specification](examples/single_objective_bayes_opt/heteroskedastic_noise_tutorial.ipynb)
       - Multiple acquisition function optimization stratigies
-      - [Approximate GP model building](examples\gp_model_creation\approximate.ipynb)
-  - [`extremum_seeking`](examples\sequential\extremum_seeking.ipynb) Extremum seeking time-dependent optimization
-  - [`rcds`](examples\sequential\rcds.ipynb) Robust Conjugate Direction Search (RCDS)
-  - [`neldermead`](examples\sequential\neldermead.ipynb) Nelder-Mead Simplex
+      - [Approximate GP model building](examples/gp_model_creation/approximate.ipynb)
+  - [`extremum_seeking`](examples/sequential/extremum_seeking.ipynb) Extremum seeking time-dependent optimization
+  - [`rcds`](examples/sequential/rcds.ipynb) Robust Conjugate Direction Search (RCDS)
+  - [`neldermead`](examples/sequential/neldermead.ipynb) Nelder-Mead Simplex
 - Sampling algorithms:
   - `random` Uniform random sampling
 - Convenient YAML/JSON based input format
 - Driver programs:
-  - [`xopt-run`](examples\basic\xopt_cli.md) Run Xopt from the command line using a YAML config file
+  - [`xopt-run`](examples/basic/xopt_cli.md) Run Xopt from the command line using a YAML config file
   - `xopt.mpi.run` Parallel MPI execution using this input format
 
  **Xopt** does **not** provide:
@@ -56,22 +56,19 @@ Rather, **Xopt** asks you to define this function.
 
 Getting Started
 ===============
-[Xopt Overview PDF](assets/xopt_overview.pdf) gives an overview of Xopt's design and
-usage.
+[Xopt Overview PDF](assets/xopt_overview.pdf) - Gives an overview of Xopt's design and usage.
 
-[Xopt Built-In Generators](algorithms.md) provides a list of available algorithms
-implemented in the Xopt ```Generator``` framework.
+[Xopt Built-In Generators](algorithms.md) - Provides a list of available algorithms implemented in the Xopt ```Generator``` framework.
 
-[Simple Bayesian Optimization Example](examples/single_objective_bayes_opt/bo_tutorial.ipynb)
-shows
-Xopt usage for a simple optimization problem.
+[Simple Bayesian Optimization Example](examples/single_objective_bayes_opt/bo_tutorial.ipynb) - Shows Xopt usage for a simple optimization problem.
 
-[Xopt IPAC23 paper](https://accelconf.web.cern.ch/ipac2023/pdf/THPL164.pdf) summarizes the usage of Xopt in particle accelerator physics problems.
+[Genetic Algorithm and CLI Tool Quickstart](examples/ga/nsga2/yaml_interface/index.md) - Jump into Xopt by solving a benchmark multi-objective optimization algorithm with NSGA-II and the `xopt-run` CLI tool.
 
+[Xopt IPAC23 paper](https://accelconf.web.cern.ch/ipac2023/pdf/THPL164.pdf) - Summarizes the usage of Xopt in particle accelerator physics problems.
 
 Configuring an Xopt run
 ===============
-Xopt runs can be specified via a YAML file or dictonary input. This requires `generator`, `evaluator`, and `vocs` to be specified. An example to run a multi-objective optimiation of a user-defined function `my_function` is:
+Xopt runs can be specified via a YAML file or dictonary input. This requires `generator`, `evaluator`, and `vocs` to be specified. An example to run a multi-objective optimization of a user-defined function `my_function` is:
 ```yaml
 generator:
     name: cnsga

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,35 +19,35 @@ support for multi-threaded or MPI-enabled execution.
 Currenty **Xopt** provides:
 
 - Optimization algorithms:
-  - Genetic algorithms
-    - [`NSGA-II`](examples/ga/nsga2/index.md) Implementation of NSGA-II: Non-dominated sorting genetic algorithm
-    - [`cnsga`](examples/ga/cnsga_tnk.ipynb) NSGA-II adapted for use with "continuous generators"
-  - Bayesian optimization (BO) algorithms:
-    - [`upper_confidence_bound`](examples/single_objective_bayes_opt/upper_confidence_bound.ipynb) BO using Upper Confidence Bound acquisition function
-      (w/ or w/o constraints, serial or parallel)
-    - [`expected_improvement`](examples/single_objective_bayes_opt/bo_tutorial.ipynb) BO using Expected Improvement acquisition function
-      (w/ or w/o constraints, serial or parallel)
-    - [`mobo`](examples/multi_objective_bayes_opt/mobo.ipynb) Multi-objective BO (w/ or w/o constraints, serial or parallel)
-    - [`bayesian_exploration`](examples/bayes_exp/bayesian_exploration.ipynb) Autonomous function characterization using Bayesian
-      Exploration
-    - [`mggpo`](examples/multi_objective_bayes_opt/mggpo.ipynb) Parallelized hybrid Multi-Generation Multi-Objective Bayesian
-      optimization
-    - [`multi_fidelity`](examples/single_objective_bayes_opt/multi_fidelity_simple.ipynb) Multi-fidelity single or multi objective optimization
-    - [`BAX`](examples/single_objective_bayes_opt/bax_tutorial.ipynb) Bayesian algorithm execution using virtual measurements
-    - BO customization:
-      - [Trust region BO](examples/trust_region_bo/turbo_basics.ipynb)
-      - [Heteroskedastic noise specification](examples/single_objective_bayes_opt/heteroskedastic_noise_tutorial.ipynb)
-      - Multiple acquisition function optimization stratigies
-      - [Approximate GP model building](examples/gp_model_creation/approximate.ipynb)
-  - [`extremum_seeking`](examples/sequential/extremum_seeking.ipynb) Extremum seeking time-dependent optimization
-  - [`rcds`](examples/sequential/rcds.ipynb) Robust Conjugate Direction Search (RCDS)
-  - [`neldermead`](examples/sequential/neldermead.ipynb) Nelder-Mead Simplex
+    - Genetic algorithms
+        - [`NSGA-II`](examples/ga/nsga2/index.md) Implementation of NSGA-II: Non-dominated sorting genetic algorithm
+        - [`cnsga`](examples/ga/cnsga_tnk.ipynb) NSGA-II adapted for use with "continuous generators"
+    - Bayesian optimization (BO) algorithms:
+        - [`upper_confidence_bound`](examples/single_objective_bayes_opt/upper_confidence_bound.ipynb) BO using Upper Confidence Bound acquisition function
+          (w/ or w/o constraints, serial or parallel)
+        - [`expected_improvement`](examples/single_objective_bayes_opt/bo_tutorial.ipynb) BO using Expected Improvement acquisition function
+          (w/ or w/o constraints, serial or parallel)
+        - [`mobo`](examples/multi_objective_bayes_opt/mobo.ipynb) Multi-objective BO (w/ or w/o constraints, serial or parallel)
+        - [`bayesian_exploration`](examples/bayes_exp/bayesian_exploration.ipynb) Autonomous function characterization using Bayesian
+          Exploration
+        - [`mggpo`](examples/multi_objective_bayes_opt/mggpo.ipynb) Parallelized hybrid Multi-Generation Multi-Objective Bayesian
+          optimization
+        - [`multi_fidelity`](examples/single_objective_bayes_opt/multi_fidelity_simple.ipynb) Multi-fidelity single or multi objective optimization
+        - [`BAX`](examples/single_objective_bayes_opt/bax_tutorial.ipynb) Bayesian algorithm execution using virtual measurements
+        - BO customization:
+            - [Trust region BO](examples/trust_region_bo/turbo_basics.ipynb)
+            - [Heteroskedastic noise specification](examples/single_objective_bayes_opt/heteroskedastic_noise_tutorial.ipynb)
+            - Multiple acquisition function optimization stratigies
+            - [Approximate GP model building](examples/gp_model_creation/approximate.ipynb)
+    - [`extremum_seeking`](examples/sequential/extremum_seeking.ipynb) Extremum seeking time-dependent optimization
+    - [`rcds`](examples/sequential/rcds.ipynb) Robust Conjugate Direction Search (RCDS)
+    - [`neldermead`](examples/sequential/neldermead.ipynb) Nelder-Mead Simplex
 - Sampling algorithms:
-  - `random` Uniform random sampling
+    - `random` Uniform random sampling
 - Convenient YAML/JSON based input format
 - Driver programs:
-  - [`xopt-run`](examples/basic/xopt_cli.md) Run Xopt from the command line using a YAML config file
-  - `xopt.mpi.run` Parallel MPI execution using this input format
+    - [`xopt-run`](examples/basic/xopt_cli.md) Run Xopt from the command line using a YAML config file
+    - `xopt.mpi.run` Parallel MPI execution using this input format
 
  **Xopt** does **not** provide:
 - your custom simulation via an `evaluate` function.

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,31 +20,32 @@ Currenty **Xopt** provides:
 
 - Optimization algorithms:
   - Genetic algorithms
-    - `cnsga` Continuous NSGA-II with constraints
+    - [`cnsga`](examples\ga\cnsga_tnk.ipynb) Continuous NSGA-II with constraints
   - Bayesian optimization (BO) algorithms:
-    - `upper_confidence_bound` BO using Upper Confidence Bound acquisition function
+    - [`upper_confidence_bound`](examples\single_objective_bayes_opt\upper_confidence_bound.ipynb) BO using Upper Confidence Bound acquisition function
       (w/ or w/o constraints, serial or parallel)
-    - `expected_improvement` BO using Expected Improvement acquisition function
+    - [`expected_improvement`](examples\single_objective_bayes_opt\bo_tutorial.ipynb) BO using Expected Improvement acquisition function
       (w/ or w/o constraints, serial or parallel)
-    - `mobo` Multi-objective BO (w/ or w/o constraints, serial or parallel)
-    - `bayesian_exploration` Autonomous function characterization using Bayesian
+    - [`mobo`](examples\multi_objective_bayes_opt\mobo.ipynb) Multi-objective BO (w/ or w/o constraints, serial or parallel)
+    - [`bayesian_exploration`](examples\bayes_exp\bayesian_exploration.ipynb) Autonomous function characterization using Bayesian
       Exploration
-    - `mggpo` Parallelized hybrid Multi-Generation Multi-Objective Bayesian
+    - [`mggpo`](examples\multi_objective_bayes_opt\mggpo.ipynb) Parallelized hybrid Multi-Generation Multi-Objective Bayesian
       optimization
-    - `multi_fidelity` Multi-fidelity single or multi objective optimization
-    - `BAX` Bayesian algorithm execution using virtual measurements
+    - [`multi_fidelity`](examples\single_objective_bayes_opt\multi_fidelity_simple.ipynb) Multi-fidelity single or multi objective optimization
+    - [`BAX`](examples\single_objective_bayes_opt\bax_tutorial.ipynb) Bayesian algorithm execution using virtual measurements
     - BO customization:
-      - Trust region BO
-      - Heteroskedastic noise specification
+      - [Trust region BO](examples\trust_region_bo\turbo_basics.ipynb)
+      - [Heteroskedastic noise specification](examples\single_objective_bayes_opt\heteroskedastic_noise_tutorial.ipynb)
       - Multiple acquisition function optimization stratigies
-      - Approximate GP model building
-  - `extremum_seeking` Extremum seeking time-dependent optimization
-  - `rcds` Robust Conjugate Direction Search (RCDS)
-  - `neldermead` Nelder-Mead Simplex
+      - [Approximate GP model building](examples\gp_model_creation\approximate.ipynb)
+  - [`extremum_seeking`](examples\sequential\extremum_seeking.ipynb) Extremum seeking time-dependent optimization
+  - [`rcds`](examples\sequential\rcds.ipynb) Robust Conjugate Direction Search (RCDS)
+  - [`neldermead`](examples\sequential\neldermead.ipynb) Nelder-Mead Simplex
 - Sampling algorithms:
   - `random` Uniform random sampling
 - Convenient YAML/JSON based input format
 - Driver programs:
+  - [`xopt-run`](examples\basic\xopt_cli.md) Run Xopt from the command line using a YAML config file
   - `xopt.mpi.run` Parallel MPI execution using this input format
 
  **Xopt** does **not** provide:
@@ -56,7 +57,6 @@ Getting Started
 ===============
 [Xopt Overview PDF](assets/xopt_overview.pdf) gives an overview of Xopt's design and
 usage.
-
 
 [Xopt Built-In Generators](algorithms.md) provides a list of available algorithms
 implemented in the Xopt ```Generator``` framework.

--- a/xopt/entrypoint.py
+++ b/xopt/entrypoint.py
@@ -13,6 +13,49 @@ import yaml
 
 logger = logging.getLogger(__name__)
 
+_XOPT_INITIAL_COLS = ["xopt_candidate_idx", "xopt_runtime", "xopt_error"]
+
+
+def normalize_initial_data(df: pd.DataFrame, vocs) -> pd.DataFrame:
+    """
+    Validate and normalize a user-supplied initial-data DataFrame before
+    passing it to Xopt.add_data.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        Raw DataFrame loaded from the user's CSV.
+    vocs : VOCS
+        The VOCS object from the Xopt instance.
+
+    Returns
+    -------
+    pd.DataFrame
+        Normalized DataFrame with required VOCS columns present, xopt metadata
+        columns filled with defaults if absent, and unrecognized columns dropped.
+    """
+    missing = set(vocs.all_names) - set(df.columns)
+    if missing:
+        raise ValueError(
+            f"Initial data is missing required VOCS columns: {sorted(missing)}"
+        )
+
+    df = df.copy()
+    if "xopt_candidate_idx" not in df.columns:
+        df["xopt_candidate_idx"] = range(len(df))
+    if "xopt_runtime" not in df.columns:
+        df["xopt_runtime"] = 0.0
+    if "xopt_error" not in df.columns:
+        df["xopt_error"] = False
+
+    keep = list(vocs.all_names) + _XOPT_INITIAL_COLS
+    if "xopt_error_str" in df.columns:
+        keep = keep + ["xopt_error_str"]
+    extra = sorted(set(df.columns) - set(keep))
+    if extra:
+        logger.warning(f"Dropping unrecognized columns from initial data: {extra}")
+    return df[[c for c in keep if c in df.columns]]
+
 
 @contextmanager
 def get_executor(name, max_workers=1):
@@ -201,7 +244,10 @@ def main():
         # Seed the generator with initial data if provided
         if args.initial_data is not None:
             logger.info(f"Loading initial data from {args.initial_data}")
-            my_xopt.add_data(pd.read_csv(args.initial_data))
+            initial_df = normalize_initial_data(
+                pd.read_csv(args.initial_data), my_xopt.vocs
+            )
+            my_xopt.add_data(initial_df)
 
         # Run Xopt
         my_xopt.run()

--- a/xopt/entrypoint.py
+++ b/xopt/entrypoint.py
@@ -6,6 +6,7 @@ from contextlib import contextmanager
 import argparse
 import logging
 import os
+import pandas as pd
 import sys
 import yaml
 
@@ -127,6 +128,12 @@ def main():
         default=[],
     )
     parser.add_argument(
+        "--initial_data",
+        help="CSV file with initial data to seed the generator before running",
+        type=str,
+        default=None,
+    )
+    parser.add_argument(
         "-v", "--verbose", action="store_true", help="Enable verbose output"
     )
     args = parser.parse_args()
@@ -190,6 +197,11 @@ def main():
         # Handle max_worker override
         if args.max_workers is not None:
             my_xopt.evaluator.max_workers = args.max_workers
+
+        # Seed the generator with initial data if provided
+        if args.initial_data is not None:
+            logger.info(f"Loading initial data from {args.initial_data}")
+            my_xopt.add_data(pd.read_csv(args.initial_data))
 
         # Run Xopt
         my_xopt.run()

--- a/xopt/tests/test_entrypoint.py
+++ b/xopt/tests/test_entrypoint.py
@@ -99,3 +99,13 @@ class TestEntryPointScript:
         df["xopt_error_str"] = "some error"
         result = normalize_initial_data(df, tnk_vocs)
         assert "xopt_error_str" in result.columns
+
+    def test_normalize_initial_data_preserves_existing_xopt_cols(self):
+        df = _tnk_df(n=3)
+        df["xopt_candidate_idx"] = [10, 20, 30]
+        df["xopt_runtime"] = [1.1, 2.2, 3.3]
+        df["xopt_error"] = [True, False, True]
+        result = normalize_initial_data(df, tnk_vocs)
+        assert list(result["xopt_candidate_idx"]) == [10, 20, 30]
+        assert list(result["xopt_runtime"]) == [1.1, 2.2, 3.3]
+        assert list(result["xopt_error"]) == [True, False, True]

--- a/xopt/tests/test_entrypoint.py
+++ b/xopt/tests/test_entrypoint.py
@@ -93,3 +93,9 @@ class TestEntryPointScript:
         df["extra_col"] = 999
         result = normalize_initial_data(df, tnk_vocs)
         assert "extra_col" not in result.columns
+
+    def test_normalize_initial_data_keeps_xopt_error_str(self):
+        df = _tnk_df()
+        df["xopt_error_str"] = "some error"
+        result = normalize_initial_data(df, tnk_vocs)
+        assert "xopt_error_str" in result.columns

--- a/xopt/tests/test_entrypoint.py
+++ b/xopt/tests/test_entrypoint.py
@@ -100,6 +100,35 @@ class TestEntryPointScript:
         result = normalize_initial_data(df, tnk_vocs)
         assert "xopt_error_str" in result.columns
 
+    @mock.patch("xopt.entrypoint.normalize_initial_data")
+    @mock.patch("xopt.entrypoint.pd.read_csv")
+    @mock.patch("xopt.entrypoint.remove_none_values", side_effect=lambda x: x)
+    @mock.patch("xopt.entrypoint.Xopt")
+    def test_main_with_initial_data(
+        self, mock_Xopt, mock_remove_none, mock_read_csv, mock_normalize, tmp_path
+    ):
+        config_path, config = self.make_config(tmp_path)
+        csv_path = str(tmp_path / "initial.csv")
+
+        sentinel_df = pd.DataFrame({"x1": [1.0]})
+        mock_read_csv.return_value = sentinel_df
+        mock_normalize.return_value = sentinel_df
+
+        mock_xopt_instance = mock.Mock()
+        mock_Xopt.model_validate.return_value = mock_xopt_instance
+        mock_xopt_instance.run.return_value = None
+
+        sys_argv = ["entrypoint.py", config_path, "--initial_data", csv_path]
+        with mock.patch.object(sys, "argv", sys_argv):
+            with mock.patch(
+                "builtins.open", mock.mock_open(read_data=yaml.dump(config))
+            ):
+                entrypoint.main()
+
+        mock_read_csv.assert_called_once_with(csv_path)
+        mock_normalize.assert_called_once_with(sentinel_df, mock_xopt_instance.vocs)
+        mock_xopt_instance.add_data.assert_called_once_with(sentinel_df)
+
     def test_normalize_initial_data_preserves_existing_xopt_cols(self):
         df = _tnk_df(n=3)
         df["xopt_candidate_idx"] = [10, 20, 30]

--- a/xopt/tests/test_entrypoint.py
+++ b/xopt/tests/test_entrypoint.py
@@ -1,8 +1,26 @@
+import numpy as np
+import pandas as pd
 import pytest
 import sys
 import yaml
 from unittest import mock
 from xopt import entrypoint
+from xopt.entrypoint import normalize_initial_data
+from xopt.resources.test_functions.tnk import tnk_vocs
+
+
+def _tnk_df(n=3):
+    return pd.DataFrame(
+        {
+            "x1": np.random.uniform(0, np.pi, n),
+            "x2": np.random.uniform(0, np.pi, n),
+            "y1": np.random.uniform(0, 1, n),
+            "y2": np.random.uniform(0, 1, n),
+            "c1": np.random.uniform(-1, 1, n),
+            "c2": np.random.uniform(0, 0.5, n),
+            "a": [1.0] * n,
+        }
+    )
 
 
 class TestEntryPointScript:
@@ -57,3 +75,21 @@ class TestEntryPointScript:
         with pytest.raises(ValueError, match="Unknown executor: bad"):
             with entrypoint.get_executor("bad"):
                 pass
+
+    def test_normalize_initial_data_missing_cols(self):
+        df = _tnk_df().drop(columns=["y2"])
+        with pytest.raises(ValueError, match="y2"):
+            normalize_initial_data(df, tnk_vocs)
+
+    def test_normalize_initial_data_adds_xopt_defaults(self):
+        df = _tnk_df()
+        result = normalize_initial_data(df, tnk_vocs)
+        assert list(result["xopt_candidate_idx"]) == list(range(len(df)))
+        assert (result["xopt_runtime"] == 0.0).all()
+        assert (result["xopt_error"] == False).all()  # noqa: E712
+
+    def test_normalize_initial_data_drops_extra_cols(self):
+        df = _tnk_df()
+        df["extra_col"] = 999
+        result = normalize_initial_data(df, tnk_vocs)
+        assert "extra_col" not in result.columns

--- a/xopt/tests/test_numerical_optimizer.py
+++ b/xopt/tests/test_numerical_optimizer.py
@@ -195,18 +195,14 @@ class TestNumericalOptimizers:
 
         # can only explore one objective
         vocs.objectives = {"y1": "EXPLORE"}
-
         generator = BayesianExplorationGenerator(
             vocs=vocs, numerical_optimizer=GridOptimizer(n_grid_points=2)
         )
-
         evaluator = Evaluator(function=evaluate_TNK)
-
         X = Xopt(generator=generator, evaluator=evaluator)
 
-        X.evaluate_data(
-            pd.DataFrame({"x1": [3.14, 3.14, 0], "x2": [3.14, 0, 3.14]})
-        )
+        # sample at corners of the design space except for the origin
+        X.evaluate_data(pd.DataFrame({"x1": [3.14, 3.14, 0], "x2": [3.14, 0, 3.14]}))
 
         X.step()
         assert np.allclose(

--- a/xopt/tests/test_numerical_optimizer.py
+++ b/xopt/tests/test_numerical_optimizer.py
@@ -205,7 +205,7 @@ class TestNumericalOptimizers:
         X = Xopt(generator=generator, evaluator=evaluator)
 
         X.evaluate_data(
-            pd.DataFrame({"x1": [1.0, 0.75, 3.14, 0], "x2": [0.7, 0.95, 0, 3.14]})
+            pd.DataFrame({"x1": [3.14, 3.14, 0], "x2": [3.14, 0, 3.14]})
         )
 
         X.step()


### PR DESCRIPTION
This PR adds a new argument `--initial_data` to the `xopt-run` CLI tool. This argument will load a CSV file and route it to `Xopt.add_data(...)` before the optimizer is run. Other changes are the following.
- Add new argument to the `xopt-run` documentation page.
- Add reference to `xopt-run` on main `index.md` page.
- Add relevant links to each of the generators / tools referenced in the list of features on main `index.md` page.
- Add NSGA-II to list of optimizers and quickstart section in main `index.md`.
- Formatting fixes in `index.md`: correct indentation, spelling.