### PR TITLE
Bugfix: `NSGA2Generator._generate` Variable Ordering

### DIFF
--- a/xopt/generators/ga/nsga2.py
+++ b/xopt/generators/ga/nsga2.py
@@ -624,7 +624,7 @@ class NSGA2Generator(DeduplicatedGeneratorBase, StateOwner):
 
             # Get runtime information for the children used in this population
             rt = [x["xopt_runtime"] for x in self.child[: self.population_size]]
-            perf_message = f"{np.mean(rt):.3f}s ({np.std(rt):.3f}s)"
+            perf_message = f"{np.mean(rt):.3f}s (+/- {np.std(rt):.3f}s)"
 
             # Generate logging message
             n_feasible = np.sum(

--- a/xopt/generators/ga/nsga2.py
+++ b/xopt/generators/ga/nsga2.py
@@ -255,6 +255,58 @@ def cull_population(
     return crowded_comparison_argsort(pop_f, pop_g)[-population_size:]
 
 
+def generate_candidates_from_population(
+    pop: list[dict],
+    vocs: VOCS,
+    n_candidates: int,
+    mutation_operator: MutationOperator,
+    crossover_operator: CrossoverOperator,
+) -> list[dict]:
+    """
+    Generate offspring from an existing population using binary tournament selection,
+    crossover, and mutation.
+
+    Parameters
+    ----------
+    pop : list[dict]
+        Current population individuals.
+    vocs : VOCS
+        VOCS object defining variables, objectives, and constraints.
+    n_candidates : int
+        Number of offspring to produce.
+    mutation_operator : MutationOperator
+        Mutation operator to apply.
+    crossover_operator : CrossoverOperator
+        Crossover operator to apply.
+
+    Returns
+    -------
+    list[dict]
+        Generated candidates with variable name keys.
+    """
+    var_names = list(vocs.variable_names)
+    pop_x = pd.DataFrame(pop)[var_names].to_numpy()
+    pop_f = get_objective_data(vocs, pop).to_numpy()
+    pop_g = vocs_data_to_arr(get_constraint_data(vocs, pop).to_numpy())
+    fitness = get_fitness(pop_f, pop_g)
+    bounds = np.array([vocs.variables[name].domain for name in var_names]).T
+
+    candidates = []
+    for _ in range(n_candidates):
+        child = generate_child_binary_tournament(
+            pop_x,
+            pop_f,
+            pop_g,
+            bounds,
+            mutate=mutation_operator,
+            crossover=crossover_operator,
+            fitness=fitness,
+        )
+        candidates.append(dict(zip(var_names, child)))
+
+    return candidates
+
+
 ########################################################################################################################
 # Optimizer class
 ########################################################################################################################
@@ -495,36 +547,13 @@ class NSGA2Generator(DeduplicatedGeneratorBase, StateOwner):
 
         # If we have a population create children, otherwise generate randomly sampled points
         if self.pop:
-            # Get the variables
-            var_names = sorted(self.vocs.variable_names)
-
-            # Generate candidates one by one
-            candidates = []
-            pop_x = get_variable_data(self.vocs, self.pop).to_numpy()
-            pop_f = get_objective_data(self.vocs, self.pop).to_numpy()
-            pop_g = vocs_data_to_arr(
-                get_constraint_data(self.vocs, self.pop).to_numpy()
+            candidates = generate_candidates_from_population(
+                self.pop,
+                self.vocs,
+                n_candidates,
+                self.mutation_operator,
+                self.crossover_operator,
             )
-            fitness = get_fitness(pop_f, pop_g)
-            bounds = np.array(self.vocs.bounds).T
-            for _ in range(n_candidates):
-                candidates.append(
-                    {
-                        k: v
-                        for k, v in zip(
-                            var_names,
-                            generate_child_binary_tournament(
-                                pop_x,
-                                pop_f,
-                                pop_g,
-                                bounds,
-                                mutate=self.mutation_operator,
-                                crossover=self.crossover_operator,
-                                fitness=fitness,
-                            ),
-                        )
-                    }
-                )
             self._logger.debug(
                 f"generated {n_candidates} candidates from generation {self.n_generations} "
                 f"in {1000 * (time.perf_counter() - start_t):.2f}ms"

--- a/xopt/tests/generators/ga/test_nsga2.py
+++ b/xopt/tests/generators/ga/test_nsga2.py
@@ -986,3 +986,37 @@ def test_nsga2_vocs_not_present_in_add_data():
     # Try with strict=False
     X.strict = False
     X.add_data(pd.DataFrame({"x1": [0], "y2": [0], "c1": [0]}))
+
+
+def test_generate_candidates_in_bounds_unsorted_vocs():
+    """
+    Test for Github issue #437. Confirm that variables out of alphabetic order are generated in unpermuted order.
+    """
+    population_size = 6
+
+    vocs = VOCS(
+        variables={
+            "z": [100.0, 101.0],
+            "a": [0.0, 1.0],
+        },
+        objectives={"f": "MINIMIZE"},
+    )
+
+    def evaluate(inputs):
+        return {"f": inputs["z"] + inputs["a"]}
+
+    X = Xopt(
+        generator=NSGA2Generator(vocs=vocs, population_size=population_size),
+        evaluator=Evaluator(function=evaluate),
+    )
+
+    for _ in range(population_size):
+        X.step()
+
+    candidates = X.generator._generate(20)
+
+    for cand in candidates:
+        z_lo, z_hi = vocs.variables["z"].domain
+        a_lo, a_hi = vocs.variables["a"].domain
+        assert z_lo <= cand["z"] <= z_hi, f"z={cand['z']!r} out of [{z_lo}, {z_hi}]"
+        assert a_lo <= cand["a"] <= a_hi, f"a={cand['a']!r} out of [{a_lo}, {a_hi}]"

--- a/xopt/tests/test_vocs.py
+++ b/xopt/tests/test_vocs.py
@@ -12,6 +12,7 @@ from xopt.vocs import (
     convert_dataframe_to_inputs,
     cumulative_optimum,
     denormalize_inputs,
+    get_constraint_data,
     get_variable_data,
     normalize_inputs,
     random_inputs,
@@ -375,6 +376,32 @@ class TestVOCS(object):
         # test using object type inside test data
         test_data["y2"] = test_data["y2"].astype(np.dtype(object))
         get_objective_data(vocs, test_data)
+
+    def test_constraint_data(self):
+        vocs = VOCS(
+            variables={"x": [0.0, 1.0]},
+            objectives={"f": "MINIMIZE"},
+            constraints={
+                "c1": ["LESS_THAN", 0.5],
+                "c2": ["GREATER_THAN", 2.0],
+            },
+        )
+
+        test_data = pd.DataFrame(
+            {
+                "x": [0.5, 0.5],
+                "c1": [0.2, 0.8],  # 0.2 satisfies c1 < 0.5, 0.8 violates it
+                "c2": [3.0, 1.0],  # 3.0 satisfies c2 > 2.0, 1.0 violates it
+            }
+        )
+
+        result = get_constraint_data(vocs, test_data)
+
+        # Satisfied constraints produce g < 0, violated produce g > 0
+        # LESS_THAN 0.5: g = c1 - 0.5
+        np.testing.assert_allclose(result["constraint_c1"].to_numpy(), [-0.3, 0.3])
+        # GREATER_THAN 2.0: g = -(c2 - 2.0)
+        np.testing.assert_allclose(result["constraint_c2"].to_numpy(), [-1.0, 1.0])
 
     def test_convert_dataframe_to_inputs(self):
         vocs = deepcopy(TEST_VOCS_BASE)


### PR DESCRIPTION
This PR is to address #437.
- A unit test that reproduces the issue was added.
- `NSGA2Generator._generate` was updated to ensure consistent ordering in the conversion of data from DataFrame to numpy array and back. It was also refactored to helper function for readability (high indent level).
- Add unit test for `get_constraint_data` to validate assumptions around conversion of constraints to canonical form.

## TODO
- [x] Add unit test that `get_constraint_data` returns canonical constraint form