### PR TITLE
Test fix

### DIFF
--- a/xopt/tests/test_numerical_optimizer.py
+++ b/xopt/tests/test_numerical_optimizer.py
@@ -195,18 +195,14 @@ class TestNumericalOptimizers:
 
         # can only explore one objective
         vocs.objectives = {"y1": "EXPLORE"}
-
         generator = BayesianExplorationGenerator(
             vocs=vocs, numerical_optimizer=GridOptimizer(n_grid_points=2)
         )
-
         evaluator = Evaluator(function=evaluate_TNK)
-
         X = Xopt(generator=generator, evaluator=evaluator)
 
-        X.evaluate_data(
-            pd.DataFrame({"x1": [3.14, 3.14, 0], "x2": [3.14, 0, 3.14]})
-        )
+        # sample at corners of the design space except for the origin
+        X.evaluate_data(pd.DataFrame({"x1": [3.14, 3.14, 0], "x2": [3.14, 0, 3.14]}))
 
         X.step()
         assert np.allclose(

--- a/xopt/tests/test_numerical_optimizer.py
+++ b/xopt/tests/test_numerical_optimizer.py
@@ -205,7 +205,7 @@ class TestNumericalOptimizers:
         X = Xopt(generator=generator, evaluator=evaluator)
 
         X.evaluate_data(
-            pd.DataFrame({"x1": [1.0, 0.75, 3.14, 0], "x2": [0.7, 0.95, 0, 3.14]})
+            pd.DataFrame({"x1": [3.14, 3.14, 0], "x2": [3.14, 0, 3.14]})
         )
 
         X.step()


### PR DESCRIPTION
This pull request updates the test data used in the `test_in_xopt` method in `xopt/tests/test_numerical_optimizer.py` to sample at the corners of the design space (except for the origin) rather than using the previous set of points. This change helps reduce stochastic failures

- Testing improvements:
  * Updated the `test_in_xopt` test to evaluate data at the corners of the design space (excluding the origin) instead of the previous points, improving test coverage and intent.