### PR TITLE
More Extensive Test for `NSGA2Generator._generate` Permutation

### DIFF
--- a/xopt/tests/generators/ga/test_nsga2.py
+++ b/xopt/tests/generators/ga/test_nsga2.py
@@ -988,35 +988,53 @@ def test_nsga2_vocs_not_present_in_add_data():
     X.add_data(pd.DataFrame({"x1": [0], "y2": [0], "c1": [0]}))
 
 
-def test_generate_candidates_in_bounds_unsorted_vocs():
+@pytest.mark.parametrize("seed", range(4))
+def test_generate_candidates_in_bounds_unsorted_vocs(seed):
     """
     Test for Github issue #437. Confirm that variables out of alphabetic order are generated in unpermuted order.
     """
-    population_size = 6
+    np.random.seed(seed)
+
+    population_size = 8
+    n_vars = 32
+
+    # Shuffle variable names into non-alphabetical insertion order
+    var_names = [f"var_{i:02d}" for i in range(n_vars)]
+    np.random.shuffle(var_names)
+
+    # Assign non-overlapping bounds [k+1, k+1.5] to the k-th name in shuffled order
+    variables = {
+        name: [float(k + 1), float(k + 1) + 0.5] for k, name in enumerate(var_names)
+    }
 
     vocs = VOCS(
-        variables={
-            "z": [100.0, 101.0],
-            "a": [0.0, 1.0],
-        },
+        variables=variables,
         objectives={"f": "MINIMIZE"},
     )
 
     def evaluate(inputs):
-        return {"f": inputs["z"] + inputs["a"]}
+        return {"f": sum(inputs[name] for name in var_names)}
 
     X = Xopt(
         generator=NSGA2Generator(vocs=vocs, population_size=population_size),
         evaluator=Evaluator(function=evaluate),
     )
 
-    for _ in range(population_size):
+    # Test for initial random sampling
+    candidates = X.generator._generate(20)
+    for cand in candidates:
+        for k, name in enumerate(var_names):
+            lo = float(k + 1)
+            hi = lo + 0.5
+            assert lo <= cand[name] <= hi, f"{name}={cand[name]!r} out of [{lo}, {hi}]"
+
+    for _ in range(2 * population_size):
         X.step()
 
+    # Test for crossover / mutation
     candidates = X.generator._generate(20)
-
     for cand in candidates:
-        z_lo, z_hi = vocs.variables["z"].domain
-        a_lo, a_hi = vocs.variables["a"].domain
-        assert z_lo <= cand["z"] <= z_hi, f"z={cand['z']!r} out of [{z_lo}, {z_hi}]"
-        assert a_lo <= cand["a"] <= a_hi, f"a={cand['a']!r} out of [{a_lo}, {a_hi}]"
+        for k, name in enumerate(var_names):
+            lo = float(k + 1)
+            hi = lo + 0.5
+            assert lo <= cand[name] <= hi, f"{name}={cand[name]!r} out of [{lo}, {hi}]"


### PR DESCRIPTION
This PR adds more extensive testing for #437. Instead of testing two variables and the code path after population exists, this increase the test to generating 32 randomly named variables in shuffled order with non-overlapping bounds, generating candidates from both the random sampling code-path and the crossover/mutation code-path and confirming bounds are satisfied. This will catch a much wider variety of issues.