### PR TITLE
check last contextual variable value for nans and raise error

### DIFF
--- a/xopt/generators/bayesian/bayesian_generator.py
+++ b/xopt/generators/bayesian/bayesian_generator.py
@@ -411,9 +411,12 @@ class BayesianGenerator(Generator, ABC):
             # dict to track runtimes
             timing_results = {}
 
+            training_data = self.get_training_data(self.data)
+            self._validate_contextual_variables_no_nan(training_data)
+
             # update internal model with internal data
             start_time = time.perf_counter()
-            model = self.train_model(self.get_training_data(self.data))
+            model = self.train_model(training_data)
             timing_results["training"] = time.perf_counter() - start_time
 
             # propose candidates given model
@@ -934,6 +937,22 @@ class BayesianGenerator(Generator, ABC):
                     variable_bounds[key] = bounds
 
         return variable_bounds
+
+    def _validate_contextual_variables_no_nan(self, data: pd.DataFrame):
+        if data.empty:
+            return
+
+        last_row = data.iloc[-1]
+        contextual_with_nan = [
+            name
+            for name in self.contextual_variables
+            if name in data.columns and pd.isna(last_row[name])
+        ]
+        if contextual_with_nan:
+            raise ValueError(
+                "latest row contains NaN in contextual variable columns: "
+                + ", ".join(contextual_with_nan)
+            )
 
     @property
     def _candidate_names(self):

--- a/xopt/generators/bayesian/bayesian_generator.py
+++ b/xopt/generators/bayesian/bayesian_generator.py
@@ -939,9 +939,7 @@ class BayesianGenerator(Generator, ABC):
         return variable_bounds
 
     def _validate_contextual_variables_no_nan(self, data: pd.DataFrame):
-        if data.empty:
-            return
-
+        """check to make sure that the last row of data does not contain NaN in any of the contextual variable columns"""
         last_row = data.iloc[-1]
         contextual_with_nan = [
             name

--- a/xopt/tests/generators/bayesian/test_contextual_bo.py
+++ b/xopt/tests/generators/bayesian/test_contextual_bo.py
@@ -137,6 +137,23 @@ class TestContextualBO:
         assert np.isclose(bounds["x2"][0], 0.3 - padding)
         assert np.isclose(bounds["x2"][1], 0.7 + padding)
 
+    def test_contextual_variable_nan_in_last_row_raises(self):
+        generator = UpperConfidenceBoundGenerator(vocs=self.vocs)
+        data = pd.DataFrame(
+            {
+                "x1": np.linspace(0.0, 1.0, 5),
+                "x2": np.array([0.3, 0.4, 0.5, 0.6, np.nan]),
+                "y": np.ones(5),
+            }
+        )
+        generator.add_data(data)
+
+        with pytest.raises(
+            ValueError,
+            match="latest row contains NaN in contextual variable columns",
+        ):
+            generator.generate(1)
+
     def test_contextual_variable_explicit_domain_overrides_data(self):
         vocs = VOCS(
             variables={"x1": [0, 1], "x2": ContextualVariable(domain=[0.2, 0.4])},


### PR DESCRIPTION
This pull request improves the handling and validation of contextual variables in the Bayesian generator by ensuring that no NaN values are present in the latest row of training data for contextual variables. It also introduces a corresponding test to verify this behavior.

Validation improvements for contextual variables:

* Added a new method `_validate_contextual_variables_no_nan` to the `BayesianGenerator` class, which checks that the most recent row of training data does not contain NaN values in any contextual variable columns and raises a `ValueError` if this condition is violated.
* Integrated the validation step into the candidate generation process by calling `_validate_contextual_variables_no_nan` before model training in the `generate` method.

Testing enhancements:

* Added a test `test_contextual_variable_nan_in_last_row_raises` to ensure that a `ValueError` is raised if the latest row contains NaN in a contextual variable column during candidate generation.