### PR TITLE
Fix compatibility with botorch 0.18, numpy 2.4+, and torch 2.13

### DIFF
--- a/xopt/generators/bayesian/bayesian_generator.py
+++ b/xopt/generators/bayesian/bayesian_generator.py
@@ -15,7 +15,7 @@ from botorch.acquisition import (
     AcquisitionFunction,
 )
 from botorch.models.model import Model
-from botorch.sampling import get_sampler
+from botorch.sampling.get_sampler import get_sampler
 from gpytorch import Module
 from pydantic import (
     Field,

--- a/xopt/generators/bayesian/objectives.py
+++ b/xopt/generators/bayesian/objectives.py
@@ -7,7 +7,7 @@ from botorch.acquisition import (
     MCAcquisitionObjective,
 )
 from botorch.acquisition.multi_objective import WeightedMCMultiOutputObjective
-from botorch.sampling import get_sampler
+from botorch.sampling.get_sampler import get_sampler
 from torch import Tensor
 from functools import partial
 

--- a/xopt/generators/sequential/rcds.py
+++ b/xopt/generators/sequential/rcds.py
@@ -780,11 +780,11 @@ class RCDSGenerator(SequentialGenerator):
             noise=self.noise,
         )
         _ = self._powell.propose()
-        self._powell.update_obj(self._sign * float(f0))
+        self._powell.update_obj(self._sign * f0.item())
 
     def _add_data(self, new_data: pd.DataFrame):
         # first update the rcds object from the last measurement
-        res = float(new_data.iloc[-1][self.vocs.objective_names].to_numpy())
+        res = new_data.iloc[-1][self.vocs.objective_names].to_numpy(dtype=float).item()
 
         if self._powell is not None:
             self._powell.update_obj(self._sign * res)

--- a/xopt/resources/testing.py
+++ b/xopt/resources/testing.py
@@ -70,6 +70,12 @@ def recursive_torch_device_scan(
         if verbose:
             print(f"{'    ' * depth}skipping basic type {type(obj)}")
         return
+    # mark before recursing so reference cycles terminate
+    if id(obj) in visited:
+        if verbose:
+            print(f"{'    ' * depth}already visited {type(obj)} at {id(obj)}")
+        return
+    visited |= {id(obj)}
     if verbose:
         print(f"{'----' * depth}scanning {type(obj)} at {id(obj)}")
     # attrs_and_slots = {


### PR DESCRIPTION
Small fixes so the test suite passes on the latest dependency versions (also tested against older ones):

- Import `get_sampler` from its defining module `botorch.sampling.get_sampler` (as botorch does internally). In botorch 0.18 the package-level re-export gets shadowed by the submodule, so the old import bound a module instead of the function.
- Use `.item()` instead of `float()` on size-1 arrays in the RCDS generator (removed in numpy 2.4).
- Mark objects as visited before recursing in `recursive_torch_device_scan` so reference cycles in torch 2.13 object graphs don't cause a `RecursionError`.

Full suite green on botorch 0.18.1 / numpy 2.5.1 / pandas 3.0.5 / torch 2.13.0 and on botorch 0.17.2 / numpy 2.3.5 / pandas 2.3.3 / torch 2.12.1.