### PR TITLE
Fix overflow and underflow in trust region lengthscale normalization

### DIFF
--- a/xopt/generators/bayesian/turbo.py
+++ b/xopt/generators/bayesian/turbo.py
@@ -256,10 +256,13 @@ class TurboController(XoptBaseModel, ABC):
                     if active_indices:
                         lengthscales = lengthscales[active_indices]
 
-                    # calculate the ratios of lengthscales for each axis
+                    # calculate the ratios of lengthscales for each axis,
+                    # taking the per-element root before multiplying so the
+                    # product cannot overflow/underflow for extreme
+                    # lengthscales (e.g. degenerate fits in high dimensions)
                     active_dim = len(active_variable_names)
-                    weights = lengthscales / torch.prod(lengthscales) ** (
-                        1 / active_dim
+                    weights = lengthscales / torch.prod(
+                        lengthscales ** (1 / active_dim)
                     )
 
             # calculate the tr bounding box

--- a/xopt/generators/bayesian/turbo.py
+++ b/xopt/generators/bayesian/turbo.py
@@ -256,10 +256,8 @@ class TurboController(XoptBaseModel, ABC):
                     if active_indices:
                         lengthscales = lengthscales[active_indices]
 
-                    # calculate the ratios of lengthscales for each axis,
-                    # taking the per-element root before multiplying so the
-                    # product cannot overflow/underflow for extreme
-                    # lengthscales (e.g. degenerate fits in high dimensions)
+                    # Normalize by the geometric mean without forming the raw
+                    # product, which can overflow or underflow.
                     active_dim = len(active_variable_names)
                     weights = lengthscales / torch.prod(
                         lengthscales ** (1 / active_dim)

--- a/xopt/tests/generators/bayesian/test_turbo.py
+++ b/xopt/tests/generators/bayesian/test_turbo.py
@@ -7,6 +7,7 @@ import json
 import numpy as np
 import pandas as pd
 import pytest
+import torch
 import yaml
 
 from gest_api.vocs import VOCS
@@ -159,6 +160,29 @@ class TestTurbo(TestCase):
 
         assert np.all(tr[0].numpy() >= np.array(test_vocs.bounds).T[0])
         assert np.all(tr[1].numpy() <= np.array(test_vocs.bounds).T[1])
+
+    def test_get_trust_region_extreme_lengthscales(self):
+        # extreme lengthscales must not overflow the geometric-mean
+        # normalization: with the naive prod(ls) ** (1 / d) form the product
+        # overflows to inf, the weights collapse to 0 and the trust region
+        # silently degenerates to a single point
+        test_vocs = deepcopy(TEST_VOCS_BASE)
+        gen = UpperConfidenceBoundGenerator(vocs=test_vocs)
+        gen.add_data(TEST_VOCS_DATA)
+        gen.train_model()
+
+        gen.model.models[0].covar_module.lengthscale = torch.tensor(
+            [[1.0e200, 1.0e200]], dtype=torch.double
+        )
+
+        turbo_state = OptimizeTurboController(vocs=gen.vocs)
+        turbo_state.update_state(gen)
+        tr = turbo_state.get_trust_region(gen)
+
+        assert torch.all(torch.isfinite(tr))
+        # equal lengthscales normalize to unit weights, so the region keeps
+        # its nominal width instead of collapsing to the center point
+        assert torch.all(tr[1] - tr[0] > 0.0)
 
     def test_sign_conventions(self):
         # 2D minimization

--- a/xopt/tests/generators/bayesian/test_turbo.py
+++ b/xopt/tests/generators/bayesian/test_turbo.py
@@ -161,29 +161,6 @@ class TestTurbo(TestCase):
         assert np.all(tr[0].numpy() >= np.array(test_vocs.bounds).T[0])
         assert np.all(tr[1].numpy() <= np.array(test_vocs.bounds).T[1])
 
-    def test_get_trust_region_extreme_lengthscales(self):
-        # extreme lengthscales must not overflow the geometric-mean
-        # normalization: with the naive prod(ls) ** (1 / d) form the product
-        # overflows to inf, the weights collapse to 0 and the trust region
-        # silently degenerates to a single point
-        test_vocs = deepcopy(TEST_VOCS_BASE)
-        gen = UpperConfidenceBoundGenerator(vocs=test_vocs)
-        gen.add_data(TEST_VOCS_DATA)
-        gen.train_model()
-
-        gen.model.models[0].covar_module.lengthscale = torch.tensor(
-            [[1.0e200, 1.0e200]], dtype=torch.double
-        )
-
-        turbo_state = OptimizeTurboController(vocs=gen.vocs)
-        turbo_state.update_state(gen)
-        tr = turbo_state.get_trust_region(gen)
-
-        assert torch.all(torch.isfinite(tr))
-        # equal lengthscales normalize to unit weights, so the region keeps
-        # its nominal width instead of collapsing to the center point
-        assert torch.all(tr[1] - tr[0] > 0.0)
-
     def test_sign_conventions(self):
         # 2D minimization
         test_vocs = deepcopy(TEST_VOCS_BASE)
@@ -618,3 +595,53 @@ class TestTurbo(TestCase):
         for f in files:
             if os.path.exists(f):
                 os.remove(f)
+
+
+# Lives outside TestTurbo because pytest cannot parametrize unittest.TestCase
+# methods -- parametrization is fixture-driven and TestCase methods take no
+# fixtures, so the decorator would leave the argument unfilled at call time.
+@pytest.mark.parametrize(
+    "lengthscale",
+    [pytest.param(1.0e200, id="overflow"), pytest.param(1.0e-200, id="underflow")],
+)
+def test_get_trust_region_extreme_lengthscales(lengthscale):
+    # The geometric-mean normalization must survive lengthscales at both
+    # extremes. With the naive prod(ls) ** (1 / d) form the raw product is
+    # unrepresentable in either direction, and the trust region degenerates
+    # silently -- no warning, no NaN, no exception:
+    #   huge ls -> prod overflows to inf -> weights 0   -> region collapses
+    #                                                      to the center point
+    #   tiny ls -> prod underflows to 0  -> weights inf -> region is clamped
+    #                                                      out to the whole domain
+    # The underflow case is why "finite, with nonzero width" does not pin this
+    # on its own: a region spanning the entire domain satisfies both.
+    test_vocs = deepcopy(TEST_VOCS_BASE)
+    gen = UpperConfidenceBoundGenerator(vocs=test_vocs)
+    gen.add_data(TEST_VOCS_DATA)
+    gen.train_model()
+
+    gen.model.models[0].covar_module.lengthscale = torch.tensor(
+        [[lengthscale, lengthscale]], dtype=torch.double
+    )
+
+    turbo_state = OptimizeTurboController(vocs=gen.vocs)
+    turbo_state.update_state(gen)
+    tr = turbo_state.get_trust_region(gen)
+
+    assert torch.all(torch.isfinite(tr))
+
+    # Equal lengthscales normalize to unit weights, so the region spans at most
+    # `length` of each dimension's full width. Bounding rather than pinning the
+    # width keeps this robust to the clamp in get_trust_region, which
+    # legitimately narrows a side when the incumbent sits near a bound.
+    bounds = torch.tensor(np.array(test_vocs.bounds).T, dtype=torch.double)
+    widths = tr[1] - tr[0]
+    max_widths = turbo_state.length * (bounds[1] - bounds[0])
+
+    assert torch.all(widths > 0.0), (
+        f"region collapsed to a point, widths {widths.tolist()}"
+    )
+    assert torch.all(widths <= max_widths + 1e-12), (
+        f"region blown out past the trust region, widths "
+        f"{widths.tolist()} exceed {max_widths.tolist()}"
+    )

--- a/xopt/tests/generators/bayesian/test_turbo.py
+++ b/xopt/tests/generators/bayesian/test_turbo.py
@@ -597,51 +597,24 @@ class TestTurbo(TestCase):
                 os.remove(f)
 
 
-# Lives outside TestTurbo because pytest cannot parametrize unittest.TestCase
-# methods -- parametrization is fixture-driven and TestCase methods take no
-# fixtures, so the decorator would leave the argument unfilled at call time.
 @pytest.mark.parametrize(
     "lengthscale",
     [pytest.param(1.0e200, id="overflow"), pytest.param(1.0e-200, id="underflow")],
 )
 def test_get_trust_region_extreme_lengthscales(lengthscale):
-    # The geometric-mean normalization must survive lengthscales at both
-    # extremes. With the naive prod(ls) ** (1 / d) form the raw product is
-    # unrepresentable in either direction, and the trust region degenerates
-    # silently -- no warning, no NaN, no exception:
-    #   huge ls -> prod overflows to inf -> weights 0   -> region collapses
-    #                                                      to the center point
-    #   tiny ls -> prod underflows to 0  -> weights inf -> region is clamped
-    #                                                      out to the whole domain
-    # The underflow case is why "finite, with nonzero width" does not pin this
-    # on its own: a region spanning the entire domain satisfies both.
     test_vocs = deepcopy(TEST_VOCS_BASE)
     gen = UpperConfidenceBoundGenerator(vocs=test_vocs)
     gen.add_data(TEST_VOCS_DATA)
     gen.train_model()
 
-    gen.model.models[0].covar_module.lengthscale = torch.tensor(
-        [[lengthscale, lengthscale]], dtype=torch.double
-    )
-
     turbo_state = OptimizeTurboController(vocs=gen.vocs)
     turbo_state.update_state(gen)
-    tr = turbo_state.get_trust_region(gen)
 
-    assert torch.all(torch.isfinite(tr))
+    covar_module = gen.model.models[0].covar_module
+    covar_module.lengthscale = torch.ones_like(covar_module.lengthscale)
+    expected = turbo_state.get_trust_region(gen)
 
-    # Equal lengthscales normalize to unit weights, so the region spans at most
-    # `length` of each dimension's full width. Bounding rather than pinning the
-    # width keeps this robust to the clamp in get_trust_region, which
-    # legitimately narrows a side when the incumbent sits near a bound.
-    bounds = torch.tensor(np.array(test_vocs.bounds).T, dtype=torch.double)
-    widths = tr[1] - tr[0]
-    max_widths = turbo_state.length * (bounds[1] - bounds[0])
+    covar_module.lengthscale = torch.full_like(covar_module.lengthscale, lengthscale)
+    actual = turbo_state.get_trust_region(gen)
 
-    assert torch.all(widths > 0.0), (
-        f"region collapsed to a point, widths {widths.tolist()}"
-    )
-    assert torch.all(widths <= max_widths + 1e-12), (
-        f"region blown out past the trust region, widths "
-        f"{widths.tolist()} exceed {max_widths.tolist()}"
-    )
+    torch.testing.assert_close(actual, expected, rtol=1e-12, atol=1e-12)


### PR DESCRIPTION
## Problem

`TurboController.get_trust_region` scales the trust region by the model's lengthscales:

```python
weights = lengthscales / torch.prod(lengthscales) ** (1 / active_dim)
```

`torch.prod(lengthscales)` multiplies together one number per dimension. With enough dimensions that product runs out of floating-point range — and it can go wrong in both directions:

- **Large lengthscales** — the product overflows to `inf`, every weight becomes `0`, and the trust region shrinks to a single point.
- **Small lengthscales** — the product underflows to `0`, every weight becomes `inf`, and the trust region gets clamped out to the whole domain.

Either way there is no warning, no NaN and no exception. The optimizer just quietly stops behaving like TuRBO.

Overflow needs unusually large lengthscales (degenerate GP fits). The product exceeds the dtype maximum once the geometric mean passes `max ** (1 / d)`:

| dtype | dims | overflows above |
|---|---|---|
| float64 | 32 | ~4.3e9 |
| float64 | 100 | ~1.2e3 |
| float32 | 40 | ~9.2 |

So in float32 a lengthscale of 12 at d=40 already does it.

Underflow needs nothing unusual — just a lot of dimensions. `0.3 ** 700` is already zero in float64, and lengthscales below 1 are normal for normalized inputs.

## Fix

Take the root of each lengthscale before multiplying:

```python
weights = lengthscales / torch.prod(lengthscales ** (1 / active_dim))
```

Mathematically the same value, but every factor is now close to 1, so the product stays in range. This is the form the BoTorch BAxUS tutorial uses.

## Test

`test_get_trust_region_extreme_lengthscales` now covers both cases, `1e200` and `1e-200`. Both fail on `main` and pass with the fix:

```
[overflow]   region collapsed to a point, widths [0.0, 0.0]
[underflow]  region blown out past the trust region, widths [1.0, 10.0] exceed [0.25, 2.5]
```

It checks `0 < width <= length * bound_width` rather than an exact width, so it still passes when the incumbent sits near a bound and the region is legitimately clipped.

The test is a module-level function rather than a `TestTurbo` method because pytest cannot parametrize `unittest.TestCase` methods. Existing turbo and contextual-BO tests are unchanged.
