### PR TITLE
Data CSV Dump Attribute

### DIFF
--- a/docs/examples/basic/checkpointing_and_restarts.ipynb
+++ b/docs/examples/basic/checkpointing_and_restarts.ipynb
@@ -10,8 +10,10 @@
    },
    "source": [
     "# Checkpointing and Restarts\n",
-    "If `dump_file` is provided Xopt will save the data and the Xopt configuration in a\n",
-    "yaml file. This can be used directly to create a new Xopt object."
+    "If `xopt_dump_file` is provided Xopt will save the data and the Xopt configuration\n",
+    "in a yaml file. This can be used directly to create a new Xopt object. If\n",
+    "`data_dump_file` is provided Xopt will additionally write the evaluation data to a\n",
+    "csv file."
    ]
   },
   {
@@ -30,7 +32,7 @@
     "\n",
     "# Make a proper input file.\n",
     "YAML = \"\"\"\n",
-    "dump_file: dump.yml\n",
+    "xopt_dump_file: dump.yml\n",
     "generator:\n",
     "    name: random\n",
     "    vocs:\n",

--- a/xopt/base.py
+++ b/xopt/base.py
@@ -40,6 +40,11 @@ from .errors import DataError
 
 logger = logging.getLogger(__name__)
 
+DUMP_FILE_RENAME_MESSAGE = (
+    "The attribute `dump_file` in `Xopt` has been renamed to `xopt_dump_file`. "
+    "Support for the old name will be removed in later versions of the Xopt library."
+)
+
 
 class Xopt(XoptBaseModel):
     """
@@ -59,9 +64,11 @@ class Xopt(XoptBaseModel):
     strict : bool, optional
         A flag indicating whether exceptions raised during evaluation should stop the
         optimization process.
-    dump_file : str, optional
+    xopt_dump_file : str, optional
         An optional file path for dumping attributes of the xopt object and the
         results of evaluations.
+    data_dump_file : str, optional
+        An optional file path for dumping the evaluation data as a CSV file.
     data : DataFrame, optional
         An optional DataFrame object for storing internal data related to the optimization
         process.
@@ -96,8 +103,8 @@ class Xopt(XoptBaseModel):
         Xopt.
     yaml(**kwargs)
         Serializes the Xopt configuration to a YAML string.
-    dump(file: str = None, **kwargs)
-        Dumps the Xopt configuration to a specified file.
+    dump(file: str = None, data_file: str = None, **kwargs)
+        Dumps the Xopt configuration and/or the evaluation data to the specified files.
     dict(**kwargs) -> dict
         Provides a custom dictionary representation of the Xopt configuration.
     json(**kwargs) -> str
@@ -115,8 +122,11 @@ class Xopt(XoptBaseModel):
         description="flag to indicate if exceptions raised during evaluation "
         "should stop Xopt",
     )
-    dump_file: Optional[str] = Field(
-        None, description="file to dump the results of the evaluations"
+    xopt_dump_file: Optional[str] = Field(
+        None, description="file to dump the serialized Xopt object to"
+    )
+    data_dump_file: Optional[str] = Field(
+        None, description="file to dump the evaluation data to as CSV"
     )
     data: Optional[DataFrame] = Field(None, description="internal DataFrame object")
     serialize_torch: bool = Field(
@@ -242,6 +252,33 @@ class Xopt(XoptBaseModel):
                 max_evaluations=max_evals
             )
         return data
+
+    @model_validator(mode="before")
+    @classmethod
+    def dump_file_legacy(cls, data: Any):
+        """
+        Handle backward compatibility: convert the old dump_file parameter to
+        xopt_dump_file.
+        """
+        if isinstance(data, dict) and "dump_file" in data:
+            warnings.warn(DUMP_FILE_RENAME_MESSAGE, DeprecationWarning, stacklevel=2)
+            if data.get("xopt_dump_file") is not None:
+                raise ValueError(
+                    "Cannot specify both 'dump_file' and 'xopt_dump_file'. "
+                    "Use 'xopt_dump_file' instead."
+                )
+            data["xopt_dump_file"] = data.pop("dump_file")
+        return data
+
+    @property
+    def dump_file(self) -> Optional[str]:
+        warnings.warn(DUMP_FILE_RENAME_MESSAGE, DeprecationWarning, stacklevel=2)
+        return self.xopt_dump_file
+
+    @dump_file.setter
+    def dump_file(self, value: Optional[str]):
+        warnings.warn(DUMP_FILE_RENAME_MESSAGE, DeprecationWarning, stacklevel=2)
+        self.xopt_dump_file = value
 
     @property
     def n_data(self) -> int:
@@ -440,9 +477,8 @@ class Xopt(XoptBaseModel):
 
         self.add_data(output_data)
 
-        # dump data to file if specified
-        if self.dump_file is not None:
-            self.dump()
+        # dump to file(s) if specified
+        self.dump()
 
         return output_data
 
@@ -622,33 +658,37 @@ class Xopt(XoptBaseModel):
         )
         return yaml.dump(output)
 
-    def dump(self, file: str = None, **kwargs):
+    def dump(self, file: str = None, data_file: str = None, **kwargs):
         """
-        Dump data to a file.
+        Dump the Xopt object and/or the evaluation data to file.
+
+        Each target is written only if a path is available for it, either via argument
+        or via the corresponding attribute. If neither is available nothing is written.
 
         Parameters
         ----------
         file : str, optional
-            The path to the file where the Xopt configuration will be dumped.
+            The path to the YAML file where the Xopt configuration will be dumped.
+            Defaults to the `xopt_dump_file` attribute.
+        data_file : str, optional
+            The path to the CSV file where the evaluation data will be dumped.
+            Defaults to the `data_dump_file` attribute.
         **kwargs
-            Additional keyword arguments for customizing the dump.
-
-        Raises
-        ------
-        ValueError
-            If no dump file is specified via argument or in the `dump_file` attribute.
+            Additional keyword arguments for customizing the YAML serialization.
 
         """
-        fname = file if file is not None else self.dump_file
+        fname = file if file is not None else self.xopt_dump_file
+        data_fname = data_file if data_file is not None else self.data_dump_file
 
-        if fname is None:
-            raise ValueError(
-                "no dump file specified via argument or in `dump_file` attribute"
-            )
-        else:
+        if fname is not None:
             with open(fname, "w") as f:
                 f.write(self.yaml(**kwargs))
             logger.debug(f"Dumped state to YAML file: {fname}")
+
+        if data_fname is not None:
+            data = self.data if self.data is not None else pd.DataFrame()
+            data.to_csv(data_fname, index_label="xopt_index")
+            logger.debug(f"Dumped data to CSV file: {data_fname}")
 
     def dict(self, **kwargs) -> dict:
         """

--- a/xopt/base.py
+++ b/xopt/base.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import os
 from copy import deepcopy
 from typing import Any, Optional, Union
 
@@ -66,9 +67,10 @@ class Xopt(XoptBaseModel):
         optimization process.
     xopt_dump_file : str, optional
         An optional file path for dumping attributes of the xopt object and the
-        results of evaluations.
+        results of evaluations. Environment variables are expanded when dumping.
     data_dump_file : str, optional
         An optional file path for dumping the evaluation data as a CSV file.
+        Environment variables are expanded when dumping.
     data : DataFrame, optional
         An optional DataFrame object for storing internal data related to the optimization
         process.
@@ -664,6 +666,8 @@ class Xopt(XoptBaseModel):
 
         Each target is written only if a path is available for it, either via argument
         or via the corresponding attribute. If neither is available nothing is written.
+        Environment variables in the paths are expanded here, so the unexpanded paths
+        are the ones stored on the object and written to the serialized configuration.
 
         Parameters
         ----------
@@ -681,11 +685,13 @@ class Xopt(XoptBaseModel):
         data_fname = data_file if data_file is not None else self.data_dump_file
 
         if fname is not None:
+            fname = os.path.expandvars(fname)
             with open(fname, "w") as f:
                 f.write(self.yaml(**kwargs))
             logger.debug(f"Dumped state to YAML file: {fname}")
 
         if data_fname is not None:
+            data_fname = os.path.expandvars(data_fname)
             data = self.data if self.data is not None else pd.DataFrame()
             data.to_csv(data_fname, index_label="xopt_index")
             logger.debug(f"Dumped data to CSV file: {data_fname}")

--- a/xopt/base.py
+++ b/xopt/base.py
@@ -105,8 +105,10 @@ class Xopt(XoptBaseModel):
         Xopt.
     yaml(**kwargs)
         Serializes the Xopt configuration to a YAML string.
-    dump(file: str = None, data_file: str = None, **kwargs)
-        Dumps the Xopt configuration and/or the evaluation data to the specified files.
+    dump(file: str = None, **kwargs)
+        Dumps the Xopt configuration to a specified file.
+    dump_data()
+        Dumps the evaluation data to the file given by `data_dump_file`.
     dict(**kwargs) -> dict
         Provides a custom dictionary representation of the Xopt configuration.
     json(**kwargs) -> str
@@ -482,7 +484,10 @@ class Xopt(XoptBaseModel):
         self.add_data(output_data)
 
         # dump to file(s) if specified
-        self.dump()
+        if self.xopt_dump_file is not None:
+            self.dump()
+        if self.data_dump_file is not None:
+            self.dump_data()
 
         return output_data
 
@@ -662,41 +667,62 @@ class Xopt(XoptBaseModel):
         )
         return yaml.dump(output)
 
-    def dump(self, file: str = None, data_file: str = None, **kwargs):
+    def dump(self, file: str = None, **kwargs):
         """
-        Dump the Xopt object and/or the evaluation data to file.
+        Dump the Xopt configuration and data to a YAML file.
 
-        Each target is written only if a path is available for it, either via argument
-        or via the corresponding attribute. If neither is available nothing is written.
-        Environment variables in the paths are expanded here, so the unexpanded paths
-        are the ones stored on the object and written to the serialized configuration.
+        Environment variables in the path are expanded here, so the unexpanded path
+        is the one stored on the object and written to the serialized configuration.
 
         Parameters
         ----------
         file : str, optional
-            The path to the YAML file where the Xopt configuration will be dumped.
+            The path to the file where the Xopt configuration will be dumped.
             Defaults to the `xopt_dump_file` attribute.
-        data_file : str, optional
-            The path to the CSV file where the evaluation data will be dumped.
-            Defaults to the `data_dump_file` attribute.
         **kwargs
-            Additional keyword arguments for customizing the YAML serialization.
+            Additional keyword arguments for customizing the dump.
+
+        Raises
+        ------
+        ValueError
+            If no dump file is specified via argument or in the `xopt_dump_file`
+            attribute.
 
         """
         fname = file if file is not None else self.xopt_dump_file
-        data_fname = data_file if data_file is not None else self.data_dump_file
 
-        if fname is not None:
-            fname = os.path.expandvars(fname)
-            with open(fname, "w") as f:
-                f.write(self.yaml(**kwargs))
-            logger.debug(f"Dumped state to YAML file: {fname}")
+        if fname is None:
+            raise ValueError(
+                "no dump file specified via argument or in `xopt_dump_file` attribute"
+            )
 
-        if data_fname is not None:
-            data_fname = os.path.expandvars(data_fname)
-            data = self.data if self.data is not None else pd.DataFrame()
-            data.to_csv(data_fname, index_label="xopt_index")
-            logger.debug(f"Dumped data to CSV file: {data_fname}")
+        fname = os.path.expandvars(fname)
+        with open(fname, "w") as f:
+            f.write(self.yaml(**kwargs))
+        logger.debug(f"Dumped state to YAML file: {fname}")
+
+    def dump_data(self):
+        """
+        Dump the evaluation data to the CSV file given by `data_dump_file`.
+
+        Environment variables in the path are expanded here, so the unexpanded path
+        is the one stored on the object and written to the serialized configuration.
+
+        Raises
+        ------
+        ValueError
+            If no data dump file is specified in the `data_dump_file` attribute.
+
+        """
+        if self.data_dump_file is None:
+            raise ValueError(
+                "no data dump file specified in `data_dump_file` attribute"
+            )
+
+        fname = os.path.expandvars(self.data_dump_file)
+        data = self.data if self.data is not None else pd.DataFrame()
+        data.to_csv(fname, index_label="xopt_index")
+        logger.debug(f"Dumped data to CSV file: {fname}")
 
     def dict(self, **kwargs) -> dict:
         """

--- a/xopt/base.py
+++ b/xopt/base.py
@@ -67,10 +67,11 @@ class Xopt(XoptBaseModel):
         optimization process.
     xopt_dump_file : str, optional
         An optional file path for dumping attributes of the xopt object and the
-        results of evaluations. Environment variables are expanded when dumping.
+        results of evaluations. Environment variables and `~` are expanded when
+        dumping.
     data_dump_file : str, optional
         An optional file path for dumping the evaluation data as a CSV file.
-        Environment variables are expanded when dumping.
+        Environment variables and `~` are expanded when dumping.
     data : DataFrame, optional
         An optional DataFrame object for storing internal data related to the optimization
         process.
@@ -671,8 +672,7 @@ class Xopt(XoptBaseModel):
         """
         Dump the Xopt configuration and data to a YAML file.
 
-        Environment variables in the path are expanded here, so the unexpanded path
-        is the one stored on the object and written to the serialized configuration.
+        Environment variables and `~` in the path are expanded.
 
         Parameters
         ----------
@@ -696,7 +696,7 @@ class Xopt(XoptBaseModel):
                 "no dump file specified via argument or in `xopt_dump_file` attribute"
             )
 
-        fname = os.path.expandvars(fname)
+        fname = os.path.expanduser(os.path.expandvars(fname))
         with open(fname, "w") as f:
             f.write(self.yaml(**kwargs))
         logger.debug(f"Dumped state to YAML file: {fname}")
@@ -705,8 +705,7 @@ class Xopt(XoptBaseModel):
         """
         Dump the evaluation data to the CSV file given by `data_dump_file`.
 
-        Environment variables in the path are expanded here, so the unexpanded path
-        is the one stored on the object and written to the serialized configuration.
+        Environment variables and `~` in the path are expanded.
 
         Raises
         ------
@@ -719,7 +718,7 @@ class Xopt(XoptBaseModel):
                 "no data dump file specified in `data_dump_file` attribute"
             )
 
-        fname = os.path.expandvars(self.data_dump_file)
+        fname = os.path.expanduser(os.path.expandvars(self.data_dump_file))
         data = self.data if self.data is not None else pd.DataFrame()
         data.to_csv(fname, index_label="xopt_index")
         logger.debug(f"Dumped data to CSV file: {fname}")

--- a/xopt/base.py
+++ b/xopt/base.py
@@ -264,12 +264,14 @@ class Xopt(XoptBaseModel):
         """
         if isinstance(data, dict) and "dump_file" in data:
             warnings.warn(DUMP_FILE_RENAME_MESSAGE, DeprecationWarning, stacklevel=2)
-            if data.get("xopt_dump_file") is not None:
-                raise ValueError(
-                    "Cannot specify both 'dump_file' and 'xopt_dump_file'. "
-                    "Use 'xopt_dump_file' instead."
-                )
-            data["xopt_dump_file"] = data.pop("dump_file")
+            dump_file = data.pop("dump_file")
+            if dump_file is not None:
+                if data.get("xopt_dump_file") is not None:
+                    raise ValueError(
+                        "Cannot specify both 'dump_file' and 'xopt_dump_file'. "
+                        "Use 'xopt_dump_file' instead."
+                    )
+                data["xopt_dump_file"] = dump_file
         return data
 
     @property

--- a/xopt/tests/generators/bayesian/test_high_level.py
+++ b/xopt/tests/generators/bayesian/test_high_level.py
@@ -90,7 +90,7 @@ class TestHighLevel:
 
     def test_restart_torch_inline_serialization(self):
         YAML = """
-                dump_file: dump_inline.yml
+                xopt_dump_file: dump_inline.yml
                 serialize_torch: True
                 serialize_inline: True
 
@@ -136,7 +136,7 @@ class TestHighLevel:
 
     def test_restart_torch_serialization(self):
         YAML = """
-                dump_file: dump.yml
+                xopt_dump_file: dump.yml
                 serialize_torch: True
 
                 generator:
@@ -179,7 +179,7 @@ class TestHighLevel:
 
     def test_restart(self):
         YAML = """
-                dump_file: dump.yml
+                xopt_dump_file: dump.yml
                 generator:
                     name: mobo
                     reference_point: {y1: 1.5, y2: 1.5}

--- a/xopt/tests/generators/bayesian/test_turbo.py
+++ b/xopt/tests/generators/bayesian/test_turbo.py
@@ -489,7 +489,7 @@ class TestTurbo(TestCase):
             X = Xopt(
                 evaluator=evaluator,
                 generator=generator,
-                dump_file="dump.yml",
+                xopt_dump_file="dump.yml",
             )
 
             yaml_str = X.yaml()

--- a/xopt/tests/generators/ga/test_cnsga.py
+++ b/xopt/tests/generators/ga/test_cnsga.py
@@ -83,7 +83,7 @@ def test_cnsga_from_yaml():
     stopping_condition:
         name: MaxEvaluationsCondition
         max_evaluations: 10
-    dump_file: null
+    xopt_dump_file: null
     data: null
     generator:
         name: cnsga
@@ -120,7 +120,7 @@ def test_cnsga_no_constraints():
     stopping_condition:
         name: MaxEvaluationsCondition
         max_evaluations: 10
-    dump_file: null
+    xopt_dump_file: null
     data: null
     generator:
         name: cnsga

--- a/xopt/tests/test_xopt.py
+++ b/xopt/tests/test_xopt.py
@@ -569,6 +569,25 @@ class TestXopt:
             X = Xopt(YAML)
         assert X.xopt_dump_file == "test_checkpointing.yaml"
 
+    def test_dump_file_legacy_property(self):
+        evaluator = Evaluator(function=xtest_callable)
+        generator = RandomGenerator(vocs=deepcopy(TEST_VOCS_BASE))
+
+        X = Xopt(
+            generator=generator,
+            evaluator=evaluator,
+            xopt_dump_file="test_checkpointing.yaml",
+        )
+
+        # Reading through the old name warns and gives the current value
+        with pytest.warns(DeprecationWarning, match="renamed to `xopt_dump_file`"):
+            assert X.dump_file == "test_checkpointing.yaml"
+
+        # Assigning through the old name warns and writes through
+        with pytest.warns(DeprecationWarning, match="renamed to `xopt_dump_file`"):
+            X.dump_file = "other_checkpointing.yaml"
+        assert X.xopt_dump_file == "other_checkpointing.yaml"
+
     def test_dump_file_legacy_conflict(self):
         evaluator = Evaluator(function=xtest_callable)
         generator = RandomGenerator(vocs=deepcopy(TEST_VOCS_BASE))

--- a/xopt/tests/test_xopt.py
+++ b/xopt/tests/test_xopt.py
@@ -599,6 +599,22 @@ class TestXopt:
             dumped_data, X.data, check_dtype=False, check_names=False
         )
 
+    def test_dump_file_expandvars(self, tmp_path, monkeypatch):
+        evaluator = Evaluator(function=xtest_callable)
+        generator = RandomGenerator(vocs=deepcopy(TEST_VOCS_BASE))
+
+        monkeypatch.setenv("XOPT_TEST_DUMP_DIR", str(tmp_path))
+        X = Xopt(
+            generator=generator,
+            evaluator=evaluator,
+            xopt_dump_file="$XOPT_TEST_DUMP_DIR/dump.yml",
+            data_dump_file="$XOPT_TEST_DUMP_DIR/data.csv",
+        )
+        X.random_evaluate(1)
+
+        assert os.path.exists(tmp_path / "dump.yml")
+        assert os.path.exists(tmp_path / "data.csv")
+
     def test_dump_without_files(self, tmp_path):
         evaluator = Evaluator(function=xtest_callable)
         generator = RandomGenerator(vocs=deepcopy(TEST_VOCS_BASE))

--- a/xopt/tests/test_xopt.py
+++ b/xopt/tests/test_xopt.py
@@ -54,7 +54,7 @@ class TestXopt:
 
         # init with yaml
         YAML = """
-        dump_file: null
+        xopt_dump_file: null
         data: null
         evaluator:
             function: xopt.resources.test_functions.tnk.evaluate_TNK
@@ -107,7 +107,7 @@ class TestXopt:
         """
         # init with yaml
         YAML = """
-        dump_file: null
+        xopt_dump_file: null
         data: null
         evaluator:
             function: xopt.resources.test_functions.tnk.evaluate_TNK
@@ -151,7 +151,7 @@ class TestXopt:
         """
         # init with yaml
         YAML = """
-        dump_file: null
+        xopt_dump_file: null
         data: null
         evaluator:
             function: xopt.resources.test_functions.tnk.evaluate_TNK
@@ -492,7 +492,7 @@ class TestXopt:
             generator=generator,
             evaluator=evaluator,
         )
-        X.dump_file = "test_checkpointing.yaml"
+        X.xopt_dump_file = "test_checkpointing.yaml"
 
         # test case with exploded data
         data = pd.DataFrame(
@@ -525,7 +525,7 @@ class TestXopt:
             generator=generator,
             evaluator=evaluator,
         )
-        X.dump_file = "test_checkpointing.yaml"
+        X.xopt_dump_file = "test_checkpointing.yaml"
 
         X.step()
 
@@ -533,12 +533,82 @@ class TestXopt:
             X.step()
 
         # try to load the state from nothing
-        X2 = Xopt.from_file(X.dump_file)
+        X2 = Xopt.from_file(X.xopt_dump_file)
 
         assert len(X2.data) == 6
         assert isinstance(X2.generator, RandomGenerator)
         assert isinstance(X2.evaluator, Evaluator)
         assert X.vocs == X2.vocs
+
+    def test_dump_file_legacy_name(self):
+        evaluator = Evaluator(function=xtest_callable)
+        generator = RandomGenerator(vocs=deepcopy(TEST_VOCS_BASE))
+
+        with pytest.warns(DeprecationWarning, match="renamed to `xopt_dump_file`"):
+            X = Xopt(
+                generator=generator,
+                evaluator=evaluator,
+                dump_file="test_checkpointing.yaml",
+            )
+        assert X.xopt_dump_file == "test_checkpointing.yaml"
+
+        YAML = """
+        dump_file: test_checkpointing.yaml
+        evaluator:
+            function: xopt.resources.test_functions.tnk.evaluate_TNK
+
+        generator:
+            name: random
+            vocs:
+                variables:
+                    x1: [0, 3.14159]
+                    x2: [0, 3.14159]
+                objectives: {y1: MINIMIZE}
+        """
+        with pytest.warns(DeprecationWarning, match="renamed to `xopt_dump_file`"):
+            X = Xopt(YAML)
+        assert X.xopt_dump_file == "test_checkpointing.yaml"
+
+    def test_dump_file_legacy_conflict(self):
+        evaluator = Evaluator(function=xtest_callable)
+        generator = RandomGenerator(vocs=deepcopy(TEST_VOCS_BASE))
+
+        with pytest.raises(ValidationError):
+            Xopt(
+                generator=generator,
+                evaluator=evaluator,
+                dump_file="legacy.yaml",
+                xopt_dump_file="test_checkpointing.yaml",
+            )
+
+    def test_data_dump_file(self, tmp_path):
+        evaluator = Evaluator(function=xtest_callable)
+        generator = RandomGenerator(vocs=deepcopy(TEST_VOCS_BASE))
+
+        data_dump_file = str(tmp_path / "data.csv")
+        X = Xopt(
+            generator=generator,
+            evaluator=evaluator,
+            data_dump_file=data_dump_file,
+        )
+        X.random_evaluate(3)
+
+        assert os.path.exists(data_dump_file)
+        dumped_data = pd.read_csv(data_dump_file, index_col="xopt_index")
+        pd.testing.assert_frame_equal(
+            dumped_data, X.data, check_dtype=False, check_names=False
+        )
+
+    def test_dump_without_files(self, tmp_path):
+        evaluator = Evaluator(function=xtest_callable)
+        generator = RandomGenerator(vocs=deepcopy(TEST_VOCS_BASE))
+
+        X = Xopt(generator=generator, evaluator=evaluator)
+        X.random_evaluate(1)
+
+        # no dump files specified, nothing should be written and no error raised
+        X.dump()
+        assert not list(tmp_path.iterdir())
 
     def test_random_evaluate(self):
         evaluator = Evaluator(function=xtest_callable)

--- a/xopt/tests/test_xopt.py
+++ b/xopt/tests/test_xopt.py
@@ -618,6 +618,14 @@ class TestXopt:
             dumped_data, X.data, check_dtype=False, check_names=False
         )
 
+        # dumping directly writes the same data
+        os.remove(data_dump_file)
+        X.dump_data()
+        dumped_data = pd.read_csv(data_dump_file, index_col="xopt_index")
+        pd.testing.assert_frame_equal(
+            dumped_data, X.data, check_dtype=False, check_names=False
+        )
+
     def test_dump_file_expandvars(self, tmp_path, monkeypatch):
         evaluator = Evaluator(function=xtest_callable)
         generator = RandomGenerator(vocs=deepcopy(TEST_VOCS_BASE))
@@ -639,11 +647,17 @@ class TestXopt:
         generator = RandomGenerator(vocs=deepcopy(TEST_VOCS_BASE))
 
         X = Xopt(generator=generator, evaluator=evaluator)
-        X.random_evaluate(1)
 
-        # no dump files specified, nothing should be written and no error raised
-        X.dump()
+        # no dump files specified, evaluation should not write anything or raise
+        X.random_evaluate(1)
         assert not list(tmp_path.iterdir())
+
+        # dumping explicitly requires a destination
+        with pytest.raises(ValueError):
+            X.dump()
+
+        with pytest.raises(ValueError):
+            X.dump_data()
 
     def test_random_evaluate(self):
         evaluator = Evaluator(function=xtest_callable)


### PR DESCRIPTION
This PR adds a new attribute `data_dump_file` to `Xopt` which will automatically dump `Xopt.data` to a user specified CSV file while running. This avoids users having to parse the YAML file generated from `dump_file` and extracting their data. Full list of changes:
 - New attribute `data_dump_file` for a CSV file dumped during `.run()`
 - Rename `dump_file` to `xopt_dump_file` to avoid ambiguous name with new attribute.
 - Add legacy support for old name with deprecation warnings to update
   - Before validator for existing config files
   - Properties for user code
 - Add environment variable and user home expansion in `data_dump_file` and `xopt_dump_file` 
 -  Add tests for new property, legacy support, environment variable expansion