### PR TITLE
Expand CI coverage to macOS and Windows + tweaks

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -26,12 +26,12 @@ jobs:
         group: [1, 2, 3, 4]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7.0.1
         with:
           fetch-depth: 1
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v10.0.0
         with:
           enable-cache: true
           cache-dependency-glob: "**/pyproject.toml"
@@ -39,8 +39,10 @@ jobs:
       - name: Set up Python
         run: uv python install 3.12
 
-      - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install -y libopenmpi-dev
+      - name: Set up MPI
+        uses: mpi4py/setup-mpi@v1.4.4
+        with:
+          mpi: openmpi
 
       - name: Install dependencies
         run: uv sync --extra dev
@@ -206,14 +208,14 @@ jobs:
 
       - name: Upload results artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: notebook-results-group-${{ matrix.group }}
           path: results/group-${{ matrix.group }}-results.txt
 
       - name: Upload executed notebooks
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: executed-notebooks-group-${{ matrix.group }}
           path: executed-notebooks/**/*.ipynb
@@ -228,7 +230,7 @@ jobs:
     if: always()
     steps:
       - name: Download all results
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8.0.1
         with:
           pattern: notebook-results-group-*
           merge-multiple: true
@@ -284,12 +286,12 @@ jobs:
     name: "Build Documentation"
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7.0.1
         with:
           fetch-depth: 0  # Required for setuptools_scm version calculation
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v10.0.0
         with:
           enable-cache: true
           cache-dependency-glob: "**/pyproject.toml"
@@ -301,7 +303,7 @@ jobs:
         run: uv sync --extra doc
 
       - name: Download executed notebooks
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8.0.1
         with:
           pattern: executed-notebooks-group-*
           path: downloaded-notebooks
@@ -332,7 +334,7 @@ jobs:
           mv xopt-examples.zip ./site/assets/
 
       - name: Upload docs artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5.0.0
         with:
           path: ./site
 
@@ -350,4 +352,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5.0.0

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,24 +22,21 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7.0.1
         with:
           fetch-depth: 1
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v10.0.0
         with:
           enable-cache: true
           cache-dependency-glob: "**/pyproject.toml"
 
-      - name: Set up Python ${{ matrix.python-version }}
-        run: uv python install ${{ matrix.python-version }}
+      - name: Set up Python 3.13
+        run: uv python install 3.13
 
       - name: Install dependencies
         run: uv sync --extra dev
-
-      - name: Install pre-commit
-        run: uv pip install pre-commit
 
       - name: List Python package versions
         run: uv pip list

--- a/.github/workflows/pypi_upload.yml
+++ b/.github/workflows/pypi_upload.yml
@@ -11,11 +11,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7.0.1
         with:
           fetch-depth: 0
       - name: Set up Python 3.11
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v7.0.0
         with:
           python-version: 3.11
       - name: Install pypa/build
@@ -31,6 +31,6 @@ jobs:
           --outdir dist/
           .
       - name: Publish distribution to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@v1.14.2
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/test-notebooks.yml
+++ b/.github/workflows/test-notebooks.yml
@@ -29,10 +29,10 @@ jobs:
         group: [1, 2, 3, 4]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7.0.1
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v10.0.0
         with:
           enable-cache: true
           cache-dependency-glob: "**/pyproject.toml"
@@ -40,8 +40,10 @@ jobs:
       - name: Set up Python
         run: uv python install 3.12
 
-      - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install -y libopenmpi-dev
+      - name: Set up MPI
+        uses: mpi4py/setup-mpi@v1.4.4
+        with:
+          mpi: openmpi
 
       - name: Install dependencies
         run: uv sync --extra dev
@@ -202,7 +204,7 @@ jobs:
 
       - name: Upload results artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: results-group-${{ matrix.group }}
           path: results/group-${{ matrix.group }}-results.txt
@@ -214,7 +216,7 @@ jobs:
     if: always()
     steps:
       - name: Download all results
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8.0.1
         with:
           pattern: results-group-*
           merge-multiple: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,13 +23,19 @@ jobs:
           max-deletions: 3
 
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11", "3.12", "3.13"]
+        os: [ubuntu-latest]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
+        include:
+          - os: macos-latest
+            python-version: "3.13"
+          - os: windows-latest
+            python-version: "3.13"
 
-    name: Python ${{ matrix.python-version }}
+    name: ${{ matrix.os }} / Python ${{ matrix.python-version }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -44,8 +50,23 @@ jobs:
       - name: Set up Python ${{ matrix.python-version }}
         run: uv python install ${{ matrix.python-version }}
 
-      - name: Install system dependencies
+      - name: Install system dependencies (Ubuntu)
+        if: runner.os == 'Linux'
         run: sudo apt-get update && sudo apt-get install -y libopenmpi-dev
+
+      - name: Install system dependencies (macOS)
+        if: runner.os == 'macOS'
+        run: brew install open-mpi
+
+      - name: Install system dependencies (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          choco install msmpi --yes --no-progress
+          "MSMPI_BIN=C:\Program Files\Microsoft MPI\Bin" |
+            Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          "C:\Program Files\Microsoft MPI\Bin" |
+            Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
       - name: Install dependencies
         run: uv sync --extra dev
@@ -54,6 +75,8 @@ jobs:
         run: uv pip list
 
       - name: Run tests
+        env:
+          COVERAGE_FILE: ${{ runner.temp }}/.coverage
         run: uv run pytest -n auto --cov --cov-branch --cov-report=xml
 
       - name: Upload coverage to Codecov

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,12 +37,12 @@ jobs:
 
     name: ${{ matrix.os }} / Python ${{ matrix.python-version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 1
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v10
         with:
           enable-cache: true
           cache-dependency-glob: "**/pyproject.toml"
@@ -50,23 +50,8 @@ jobs:
       - name: Set up Python ${{ matrix.python-version }}
         run: uv python install ${{ matrix.python-version }}
 
-      - name: Install system dependencies (Ubuntu)
-        if: runner.os == 'Linux'
-        run: sudo apt-get update && sudo apt-get install -y libopenmpi-dev
-
-      - name: Install system dependencies (macOS)
-        if: runner.os == 'macOS'
-        run: brew install open-mpi
-
-      - name: Install system dependencies (Windows)
-        if: runner.os == 'Windows'
-        shell: pwsh
-        run: |
-          choco install msmpi --yes --no-progress
-          "MSMPI_BIN=C:\Program Files\Microsoft MPI\Bin" |
-            Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-          "C:\Program Files\Microsoft MPI\Bin" |
-            Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+      - name: Set up MPI
+        uses: mpi4py/setup-mpi@v1
 
       - name: Install dependencies
         run: uv sync --extra dev

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,11 +29,14 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         python-version: ["3.11", "3.12", "3.13", "3.14"]
+        mpi: [openmpi]
         include:
           - os: macos-latest
             python-version: "3.13"
+            mpi: openmpi
           - os: windows-latest
             python-version: "3.13"
+            mpi: msmpi
 
     name: ${{ matrix.os }} / Python ${{ matrix.python-version }}
     steps:
@@ -52,6 +55,8 @@ jobs:
 
       - name: Set up MPI
         uses: mpi4py/setup-mpi@v1.4.4
+        with:
+          mpi: ${{ matrix.mpi }}
 
       - name: Install dependencies
         run: uv sync --extra dev

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -92,6 +92,6 @@ jobs:
           uv run pytest -n auto --cov --cov-branch --cov-report=xml
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,12 +37,12 @@ jobs:
 
     name: ${{ matrix.os }} / Python ${{ matrix.python-version }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v7.0.1
         with:
           fetch-depth: 1
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v10
+        uses: astral-sh/setup-uv@v10.0.0
         with:
           enable-cache: true
           cache-dependency-glob: "**/pyproject.toml"
@@ -51,7 +51,7 @@ jobs:
         run: uv python install ${{ matrix.python-version }}
 
       - name: Set up MPI
-        uses: mpi4py/setup-mpi@v1
+        uses: mpi4py/setup-mpi@v1.4.4
 
       - name: Install dependencies
         run: uv sync --extra dev

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -64,10 +64,32 @@ jobs:
       - name: List Python package versions
         run: uv pip list
 
-      - name: Run tests
+      - name: Run tests (Linux and macOS)
+        if: runner.os != 'Windows'
         env:
           COVERAGE_FILE: ${{ runner.temp }}/.coverage
         run: uv run pytest -n auto --cov --cov-branch --cov-report=xml
+
+      - name: Run tests (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        env:
+          COVERAGE_FILE: ${{ runner.temp }}/.coverage
+        run: |
+          $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+          $vsPath = & $vswhere -latest -products * `
+            -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 `
+            -property installationPath
+
+          if (-not $vsPath) {
+            throw "MSVC installation not found"
+          }
+
+          $devShell = Join-Path $vsPath "Common7\Tools\Launch-VsDevShell.ps1"
+          & $devShell -Arch amd64 -HostArch amd64 -SkipAutomaticLocation
+          Get-Command cl -ErrorAction Stop
+
+          uv run pytest -n auto --cov --cov-branch --cov-report=xml
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5

--- a/xopt/tests/test_log.py
+++ b/xopt/tests/test_log.py
@@ -36,6 +36,7 @@ def test_set_handler_with_logger_file():
         logger.info("file test message")
         handler.flush()
         logger.removeHandler(handler)
+        handler.close()
         with open(tmp.name) as f:
             contents = f.read()
         assert "file test message" in contents


### PR DESCRIPTION
## Summary

- add Ubuntu Python 3.14 to the existing Python test matrix
- add macOS and Windows test jobs on Python 3.13
- install MPI dependencies per operating system
- use the runner temporary directory for portable coverage data
- update various actions to newest versions to remove the Node 20 warnings; some have no updated versions.